### PR TITLE
symmetry line location

### DIFF
--- a/symmray/abelian_core.py
+++ b/symmray/abelian_core.py
@@ -896,6 +896,8 @@ class AbelianArray(BlockBase):
     ):
         self._indices = tuple(indices)
         self._blocks = dict(blocks)
+        
+        self._symmetry = self.get_class_symmetry(symmetry)
 
         if charge is None:
             if self._blocks:
@@ -907,8 +909,6 @@ class AbelianArray(BlockBase):
                 self._charge = self.symmetry.combine()
         else:
             self._charge = charge
-
-        self._symmetry = self.get_class_symmetry(symmetry)
 
         if DEBUG:
             self.check()


### PR DESCRIPTION
Hi Johnnie,

I moved the symmetry assignment line before the charge assignment line.
In the case of charge is None, the symmetry information is required.

Best, 
Gunhee