### PR TITLE
replace tensor index with autoray 'take' for torch compatibility

### DIFF
--- a/symmray/flat/flat_index.py
+++ b/symmray/flat/flat_index.py
@@ -336,7 +336,7 @@ class FlatSubIndexInfo(SubInfo):
         )
 
     def select_charge(self, charge):
-        new_subkeys = self.subkeys[(charge,), ...]
+        new_subkeys = ar.do("take", self.subkeys, (charge,), axis=0)
         return FlatSubIndexInfo(
             indices=self.indices,
             subkeys=new_subkeys,


### PR DESCRIPTION
replace tensor index with autoray 'take' function for torch compatibility in charge selection function for flat index