### PR TITLE
add conj_project method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,8 @@ Release notes for `symmray`. See also the
 
 **Enhancements:**
 
+- Added `conj_project(axis=...)` for inserting an array and its conjugate as a
+  projector with arbitrary rank, bond duality, and fermionic parity.
 - Added {func}`~symmray.interface.finfo` for querying the machine limits of
   common NumPy floating-point and complex dtypes.
 - Symmetric arrays support scalar exponentiation with `x ** p`.

--- a/docs/fermionic_arrays.md
+++ b/docs/fermionic_arrays.md
@@ -55,6 +55,13 @@ indices are all ket-like. If a network has both ket-like and bra-like open
 indices, the dual open indices of the conjugated network may need explicit
 phase flips.
 
+Use
+[`x.conj_project(axis=...)`](#symmray.fermionic_common.FermionicCommon.conj_project)
+when inserting an array together with its conjugate as a projector. `axis`
+selects the uncontracted bond. The method handles the dualities of every
+contracted axis and the global sign of odd-parity arrays for both sparse and
+flat storage.
+
 ![Conjugation with one open dual index that needs a phase flip](images/tn-conjugate-phase.png)
 
 ## Odd-parity arrays

--- a/symmray/bosonic_common.py
+++ b/symmray/bosonic_common.py
@@ -56,6 +56,23 @@ class BosonicCommon:
         """
         return self._conj_abelian(inplace=inplace)
 
+    def conj_project(self, axis=-1, inplace=False) -> "BosonicCommon":
+        """Conjugate this array for use with itself as a projector.
+
+        Parameters
+        ----------
+        axis : int, optional
+            The axis carrying the uncontracted bond. This has no effect for
+            bosonic arrays.
+        inplace : bool, optional
+            Whether to perform the operation inplace or return a new array.
+
+        Returns
+        -------
+        BosonicCommon
+        """
+        return self.conj(inplace=inplace)
+
     def dagger(self, inplace=False) -> "BosonicCommon":
         """Return the adjoint of this abelian array, including the
         indices and any subindex fusing information.
@@ -71,8 +88,16 @@ class BosonicCommon:
         """
         return self._dagger_abelian(inplace=inplace)
 
-    dagger_project_left = dagger
-    dagger_project_right = dagger
+    def dagger_project_left(self, inplace=False) -> "BosonicCommon":
+        """Return the adjoint for use as a left projector."""
+        new = self.conj_project(axis=-1, inplace=inplace)
+        return new.transpose(inplace=True)
+
+    def dagger_project_right(self, inplace=False) -> "BosonicCommon":
+        """Return the adjoint for use as a right projector."""
+        new = self.conj_project(axis=0, inplace=inplace)
+        return new.transpose(inplace=True)
+
     dagger_compose_left = dagger
     dagger_compose_right = dagger
 

--- a/symmray/fermionic_common.py
+++ b/symmray/fermionic_common.py
@@ -434,10 +434,8 @@ class FermionicCommon:
         assuming we are going to use to project from the left on another
         operator.
         """
-        new = self._dagger_abelian()
-        if new.indices[-1].dual:
-            new.phase_flip(-1, inplace=True)
-        return new
+        new = self.dagger()
+        return new._phase_project_fermionic(0, inplace=True)
 
     def dagger_compose_right(self) -> "FermionicCommon":
         """Take the dagger (conjugate transpose) of this fermionic array,
@@ -455,10 +453,36 @@ class FermionicCommon:
         assuming we are going to use to project from the right on another
         operator.
         """
-        new = self._dagger_abelian()
-        if not new.indices[0].dual:
-            new.phase_flip(0, inplace=True)
-        return new
+        new = self.dagger()
+        return new._phase_project_fermionic(new.ndim - 1, inplace=True)
+
+    def conj_project(self, axis=-1, inplace=False) -> "FermionicCommon":
+        """Conjugate this array for use with itself as a projector.
+
+        The selected axis carries the uncontracted bond. All other axes are
+        contracted back into the tensor network.
+
+        Parameters
+        ----------
+        axis : int, optional
+            The axis carrying the uncontracted bond.
+        inplace : bool, optional
+            Whether to perform the operation inplace or return a new array.
+
+        Returns
+        -------
+        FermionicCommon
+        """
+        if axis < 0:
+            axis += self.ndim
+        if not 0 <= axis < self.ndim:
+            raise ValueError(
+                f"axis {axis} is out of bounds for an array with "
+                f"{self.ndim} dimensions"
+            )
+
+        new = self.conj(inplace=inplace)
+        return new._phase_project_fermionic(axis, inplace=True)
 
     def allclose(self, other, **kwargs):
         """Check if two fermionic arrays are element-wise equal within a

--- a/symmray/flat/flat_fermionic_array.py
+++ b/symmray/flat/flat_fermionic_array.py
@@ -844,6 +844,38 @@ class FermionicArrayFlat(
 
         return new
 
+    def _phase_project_fermionic(self, axis, inplace=False):
+        """Apply the phase-only correction for a fermionic projector.
+
+        ``conj_project`` calls this after ``conj``. The dagger projector
+        wrappers call it after ``dagger``, using the bond axis after reversal.
+        Thus ``axis`` must be normalized for the current array and identifies
+        the only axis not contracted back into the tensor network.
+        """
+        new = self if inplace else self.copy()
+        bond_dual = new.indices[axis].dual
+
+        # contracted axes matching the bond duality contribute their parity
+        mask = ar.do(
+            "asarray",
+            tuple(
+                int((ax != axis) and (ix.dual is bond_dual))
+                for ax, ix in enumerate(new.indices)
+            ),
+            like=new._sectors,
+        )
+
+        # a dual bond also picks up the parity of any dummy modes
+        const = bond_dual * sum(mode.parity for mode in new.dummy_modes)
+        exponents = ar.do(
+            "matmul",
+            new._sectors % 2,
+            mask,
+            like=new.backend,
+        )
+        phase_change = ((exponents + const) % 2) * -2 + 1
+        return new.modify(phases=new.phases * phase_change)
+
     def dagger(self, phase_dual=False, inplace=False):
         """Fermionic conjugate transpose."""
         new = self._conj_abelian(inplace=inplace)

--- a/symmray/sparse/sparse_fermionic_array.py
+++ b/symmray/sparse/sparse_fermionic_array.py
@@ -642,6 +642,39 @@ class FermionicArray(
 
         return new
 
+    def _phase_project_fermionic(self, axis, inplace=False):
+        """Apply the phase-only correction for a fermionic projector.
+
+        ``conj_project`` calls this after ``conj``. The dagger projector
+        wrappers call it after ``dagger``, using the bond axis after reversal.
+        Thus ``axis`` must be normalized for the current array and identifies
+        the only axis not contracted back into the tensor network.
+        """
+        new = self if inplace else self.copy()
+        bond_dual = new.indices[axis].dual
+
+        # contracted axes matching the bond duality contribute their parity
+        axes_flip = tuple(
+            ax
+            for ax, ix in enumerate(new.indices)
+            if (ax != axis) and (ix.dual is bond_dual)
+        )
+
+        # a dual bond also picks up the parity of any dummy modes
+        const = bond_dual * sum(mode.parity for mode in new.dummy_modes)
+        phases = new.phases.copy()
+
+        for sector in new.sectors:
+            exponent = const + sum(
+                new.symmetry.parity(sector[ax]) for ax in axes_flip
+            )
+            if exponent % 2:
+                phase = -phases.pop(sector, 1)
+                if phase == -1:
+                    phases[sector] = phase
+
+        return new.modify(phases=phases)
+
     def dagger(self, phase_dual=False, inplace=False):
         """Fermionic adjoint, implements `.H` attribute.
 

--- a/symmray/sparse/sparse_vector.py
+++ b/symmray/sparse/sparse_vector.py
@@ -48,7 +48,7 @@ class BlockVector(BlockCommon, VectorCommon, SymmrayCommon):
     def check(self):
         """Check that the block vector is well formed."""
         ndims = {ar.ndim(x) for x in self.get_all_blocks()}
-        if len(ndims) != 1:
+        if len(ndims) > 1:
             raise ValueError(f"blocks have different ndims: {ndims}")
         assert self.size == sum(ar.size(s) for s in self.get_all_blocks())
 

--- a/tests/test_flat/test_flat_abelian_array.py
+++ b/tests/test_flat/test_flat_abelian_array.py
@@ -33,6 +33,33 @@ def get_zn_blocksparse_flat_compat(
     )
 
 
+class TestConjProject:
+    def test_matches_conj(self):
+        x = sr.utils.get_rand(
+            "Z2",
+            (2, 4, 6),
+            flat=True,
+            subsizes="equal",
+            seed=42,
+        )
+        expected = x.conj()
+        actual = x.conj_project(axis=1)
+        actual.test_allclose(expected)
+
+    def test_inplace(self):
+        x = sr.utils.get_rand(
+            "Z2",
+            (2, 4, 6),
+            flat=True,
+            subsizes="equal",
+            seed=42,
+        )
+        expected = x.conj()
+        actual = x.conj_project(axis=1, inplace=True)
+        assert actual is x
+        actual.test_allclose(expected)
+
+
 @pytest.mark.parametrize("symmetry", ["Z2", "Z3", "Z4"])
 @pytest.mark.parametrize(
     "shape,perm",

--- a/tests/test_flat/test_flat_fermionic_array.py
+++ b/tests/test_flat/test_flat_fermionic_array.py
@@ -10,6 +10,61 @@ from symmray.flat.flat_fermionic_array import (
 from .test_flat_abelian_array import get_zn_blocksparse_flat_compat
 
 
+class TestConjProject:
+    @pytest.mark.parametrize("dual0", (False, True))
+    @pytest.mark.parametrize("dual1", (False, True))
+    @pytest.mark.parametrize("dual2", (False, True))
+    @pytest.mark.parametrize("charge", (0, 1))
+    @pytest.mark.parametrize("axis", (0, 1, -1))
+    @pytest.mark.parametrize("inplace", (False, True))
+    def test_matches_sparse(
+        self,
+        dual0,
+        dual1,
+        dual2,
+        charge,
+        axis,
+        inplace,
+    ):
+        sparse = get_zn_blocksparse_flat_compat(
+            "Z2",
+            (2, 2, 2),
+            duals=(dual0, dual1, dual2),
+            charge=charge,
+            fermionic=True,
+            label="x",
+            seed=42,
+        )
+        sparse.randomize_phases(43, inplace=True)
+        expected = sparse.conj_project(axis=axis)
+        flat = sparse.to_flat()
+
+        actual = flat.conj_project(axis=axis, inplace=inplace)
+        assert (actual is flat) is inplace
+        actual.check()
+        actual.to_blocksparse().test_allclose(expected)
+
+    @pytest.mark.parametrize("backend", ("numpy", "jax", "torch"))
+    def test_backend(self, backend, require_backend):
+        require_backend(backend)
+        sparse = get_zn_blocksparse_flat_compat(
+            "Z2",
+            (2, 2, 2),
+            duals=(False, False, True),
+            charge=1,
+            fermionic=True,
+            label="x",
+            seed=42,
+        )
+        sparse.randomize_phases(43, inplace=True)
+        expected = sparse.conj_project(axis=1)
+
+        actual = sparse.to_flat().to(backend).conj_project(axis=1)
+        assert actual.backend == backend
+        actual.check()
+        actual.to("numpy").to_blocksparse().test_allclose(expected)
+
+
 @pytest.mark.parametrize("symmetry", ("Z2", "Z4"))
 @pytest.mark.parametrize("seed", range(5))
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])

--- a/tests/test_sparse/test_sparse_abelian_array.py
+++ b/tests/test_sparse/test_sparse_abelian_array.py
@@ -33,6 +33,21 @@ def test_z2symmetric_array_basics():
     x.test_allclose(x.copy())
 
 
+class TestConjProject:
+    def test_matches_conj(self):
+        x = sr.utils.get_rand("Z2", (2, 3, 4), seed=42)
+        expected = x.conj()
+        actual = x.conj_project(axis=1)
+        actual.test_allclose(expected)
+
+    def test_inplace(self):
+        x = sr.utils.get_rand("Z2", (2, 3, 4), seed=42)
+        expected = x.conj()
+        actual = x.conj_project(axis=1, inplace=True)
+        assert actual is x
+        actual.test_allclose(expected)
+
+
 all_symmetries = ("Z2", "Z3", "Z5", "U1", "Z2Z2", "U1U1")
 multi_symmetries = ("Z2Z2", "U1U1")
 

--- a/tests/test_sparse/test_sparse_fermionic_array.py
+++ b/tests/test_sparse/test_sparse_fermionic_array.py
@@ -6,6 +6,61 @@ import symmray as sr
 all_symmetries = ["Z2", "Z4", "U1"]
 
 
+class TestConjProject:
+    @pytest.mark.parametrize("dual0", (False, True))
+    @pytest.mark.parametrize("dual1", (False, True))
+    @pytest.mark.parametrize("dual2", (False, True))
+    @pytest.mark.parametrize("charge", (0, 1))
+    @pytest.mark.parametrize("axis", (0, 1, -1))
+    @pytest.mark.parametrize("inplace", (False, True))
+    def test_phase_rule(
+        self,
+        dual0,
+        dual1,
+        dual2,
+        charge,
+        axis,
+        inplace,
+    ):
+        x = sr.utils.get_rand(
+            "Z2",
+            (2, 2, 2),
+            duals=(dual0, dual1, dual2),
+            charge=charge,
+            fermionic=True,
+            label="x",
+            subsizes="maximal",
+            seed=42,
+        )
+        x.randomize_phases(43, inplace=True)
+        original = x.copy()
+
+        expected = original.conj()
+        normalized_axis = axis % expected.ndim
+        bond_dual = expected.indices[normalized_axis].dual
+        axes_flip = tuple(
+            ax
+            for ax, ix in enumerate(expected.indices)
+            if (ax != normalized_axis) and (ix.dual is bond_dual)
+        )
+        expected.phase_flip(*axes_flip, inplace=True)
+        if bond_dual and sum(mode.parity for mode in expected.dummy_modes) % 2:
+            expected.phase_global(inplace=True)
+
+        actual = x.conj_project(axis=axis, inplace=inplace)
+        assert (actual is x) is inplace
+        actual.check()
+        actual.test_allclose(expected)
+        if not inplace:
+            x.test_allclose(original)
+
+    @pytest.mark.parametrize("axis", (-4, 3))
+    def test_invalid_axis(self, axis):
+        x = sr.utils.get_rand("Z2", (2, 2, 2), fermionic=True, seed=42)
+        with pytest.raises(ValueError, match="out of bounds"):
+            x.conj_project(axis=axis)
+
+
 @pytest.mark.parametrize("symmetry", all_symmetries)
 @pytest.mark.parametrize("subsizes", ["equal", "maximal", None])
 @pytest.mark.parametrize("seed", range(3))

--- a/tests/test_sparse/test_sparse_fermionic_linalg.py
+++ b/tests/test_sparse/test_sparse_fermionic_linalg.py
@@ -755,18 +755,29 @@ def test_svd_projector_identity(symm, seed):
     xf = x.fuse((0, 1), (2, 3))
 
     u, _s, vh = ar.do("linalg.svd", xf)
-    udag = u.dagger_project_left()
-    vhdag = vh.dagger_project_right()
+    udag = u.dagger_project_left().unfuse_all()
+    vhdag = vh.dagger_project_right().unfuse_all()
+    u = u.unfuse_all()
+    vh = vh.unfuse_all()
+    uconj = u.conj_project(axis=-1)
+    vhconj = vh.conj_project(axis=0)
 
-    udag = udag.unfuse_all()
-    vhdag = vhdag.unfuse_all()
+    zl = ctg.einsum("abc,dec,defg->abfg", u, uconj, x)
+    zl.test_allclose(x)
+    zl = ctg.einsum("abc,cde,defg->abfg", u, udag, x)
+    zl.test_allclose(x)
+
+    zr = ctg.einsum("defg,hfg,hij->deij", x, vhconj, vh)
+    zr.test_allclose(x)
+    zr = ctg.einsum("defg,fgh,hij->deij", x, vhdag, vh)
+    zr.test_allclose(x)
 
     z = ctg.einsum(
         "abc,cde,defg,fgh,hij->abij",
-        u.unfuse_all(),
+        u,
         udag,
         x,
         vhdag,
-        vh.unfuse_all(),
+        vh,
     )
     z.test_allclose(x)


### PR DESCRIPTION
Add a `conj_project(axis=axis)` method for symmray arrays. For fermionic arrays, this is helpful when computing and inserting projectors, e.g. for various 1d compression routines like SDC.