### PR TITLE
to_dense: add index_maps kwarg so that dense->symmray->dense can easily roundtrip

### DIFF
--- a/docs/abelian_arrays.md
+++ b/docs/abelian_arrays.md
@@ -69,6 +69,35 @@ The concrete classes [`Z2Array`](#symmray.sparse.sparse_abelian_array.Z2Array),
 Use [`AbelianArray`](#AbelianArray) with an explicit symmetry for a dynamic
 symmetry such as [`ZN`](#ZN).
 
+## Dense conversion
+
+[`from_dense`](#SparseArrayCommon.from_dense) uses `index_maps` to assign each
+dense axis position to a charge sector, then packs those sectors contiguously 
+internally. Passing the same maps to `to_dense` restores the original basis 
+positions, so the dense array roundtrips without storing its ordering as tensor 
+metadata.
+
+For example, consider a merged spinful-fermion basis ordered as `(empty, down,
+up, double)`, with Z2 charges `(0, 1, 1, 0)`:
+
+```python
+array = np.diag([1.0, 2.0, 3.0, 4.0])
+index_maps = ((0, 1, 1, 0),) * array.ndim
+
+x = sr.utils.from_dense(
+    array,
+    symmetry="Z2",
+    index_maps=index_maps,
+    duals=(False, True),
+)
+
+np.testing.assert_allclose(x.to_dense(index_maps=index_maps), array)
+```
+
+Repeated charges select degeneracy offsets in occurrence order. Calling
+`to_dense()` without `index_maps` instead returns the canonical representation
+with charge sectors packed in sorted contiguous order.
+
 ## Operations
 
 The main NumPy-like operations are

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 Release notes for `symmray`. See also the [GitHub releases page](https://github.com/jcmgray/symmray/releases).
 
+## Unreleased
+
+**Enhancements:**
+
+- {meth}`~symmray.bosonic_common.BosonicCommon.to_dense` accepts explicit index maps to restore the dense basis ordering supplied to {func}`~symmray.utils.from_dense`.
+
 ## v0.3.0 (2026-08-22)
 
 **Breaking Changes:**

--- a/symmray/bosonic_common.py
+++ b/symmray/bosonic_common.py
@@ -205,16 +205,24 @@ class BosonicCommon:
         """
         return self._trace_abelian()
 
-    def to_dense(self):
+    def to_dense(self, index_maps=None):
         """Convert this abelian array to a dense array, by combining all the
         blocks into a single large array, filling in zeros where necessary.
+
+        Parameters
+        ----------
+        index_maps : Sequence[Sequence[hashable]], optional
+            For each dimension, a sequence mapping each output linear index
+            to a charge sector. Repeated charges select degeneracy offsets in
+            occurrence order. If not supplied, charge sectors are packed in
+            sorted contiguous order.
 
         Returns
         -------
         array_like
             A dense array with the same shape as this abelian array.
         """
-        return self._to_dense_abelian()
+        return self._to_dense_abelian(index_maps=index_maps)
 
     def allclose(self, other, **allclose_opts):
         """Test whether this abelian array is close to another, that is,

--- a/symmray/fermionic_common.py
+++ b/symmray/fermionic_common.py
@@ -367,11 +367,19 @@ class FermionicCommon:
 
         return c
 
-    def to_dense(self):
+    def to_dense(self, index_maps=None):
         """Return dense representation of the fermionic array, with lazy phases
         multiplied in.
+
+        Parameters
+        ----------
+        index_maps : Sequence[Sequence[hashable]], optional
+            For each dimension, a sequence mapping each output linear index
+            to a charge sector. Repeated charges select degeneracy offsets in
+            occurrence order. If not supplied, charge sectors are packed in
+            sorted contiguous order.
         """
-        return self.phase_sync()._to_dense_abelian()
+        return self.phase_sync()._to_dense_abelian(index_maps=index_maps)
 
     def squeeze(self, axis=None, inplace=False) -> "FermionicCommon":
         """Squeeze the fermionic array, removing axes of size 1. If those axes

--- a/symmray/flat/flat_array_common.py
+++ b/symmray/flat/flat_array_common.py
@@ -616,8 +616,10 @@ class FlatArrayCommon:
             **kwargs,
         )
 
-    def _to_dense_abelian(self):
-        return self._to_blocksparse_abelian()._to_dense_abelian()
+    def _to_dense_abelian(self, index_maps=None):
+        return self._to_blocksparse_abelian()._to_dense_abelian(
+            index_maps=index_maps
+        )
 
     def _map_blocks_abelian(self, fn_sector=None, fn_block=None):
         if fn_sector is not None:

--- a/symmray/sparse/sparse_array_common.py
+++ b/symmray/sparse/sparse_array_common.py
@@ -47,6 +47,53 @@ def replace_with_seq(it, index, seq):
     return (*it[:index], *seq, *it[index + 1 :])
 
 
+def calc_to_dense_permutations(indices, index_maps):
+    """Compute permutations from packed to explicitly mapped index order."""
+    index_maps = tuple(index_maps)
+    if len(index_maps) != len(indices):
+        raise ValueError(
+            f"Expected {len(indices)} index maps, got {len(index_maps)}."
+        )
+
+    permutations = []
+    for axis, (index, index_map) in enumerate(zip(indices, index_maps)):
+        index_map = tuple(index_map)
+        if len(index_map) != index.size_total:
+            raise ValueError(
+                f"Index map for axis {axis} has length {len(index_map)}, "
+                f"expected {index.size_total}."
+            )
+
+        # the multiplicity of each charge is its intra-sector dimension
+        multiplicities = defaultdict(int)
+        for charge in index_map:
+            multiplicities[charge] += 1
+
+        if dict(multiplicities) != index.chargemap:
+            raise ValueError(
+                f"Index map for axis {axis} has charge multiplicities "
+                f"{dict(multiplicities)}, expected {index.chargemap}."
+            )
+
+        # get the linearized starting indices of current contiguous sectors
+        starts = {}
+        start = 0
+        for charge, size in index.chargemap.items():
+            starts[charge] = start
+            start += size
+
+        # map contiguous index to supplied index_map order
+        offsets = defaultdict(int)
+        permutation = []
+        for charge in index_map:
+            permutation.append(starts[charge] + offsets[charge])
+            offsets[charge] += 1
+
+        permutations.append(permutation)
+
+    return permutations
+
+
 def accum_for_split(sizes):
     """Take a sequence of block sizes and return the sequence of linear
     partitions, suitable for use with the ``split`` function.
@@ -1737,8 +1784,16 @@ class SparseArrayCommon:
             preserve_array=preserve_array,
         )
 
-    def _to_dense_abelian(self):
+    def _to_dense_abelian(self, index_maps=None):
         """Convert this block array to a dense array."""
+        if index_maps is None:
+            permutations = None
+        else:
+            permutations = calc_to_dense_permutations(
+                self.indices,
+                index_maps,
+            )
+
         backend = self.backend
         _ex_array = self.get_any_array()
         _concat = ar.get_lib_fn(backend, "concatenate")
@@ -1764,7 +1819,14 @@ class SparseArrayCommon:
                 # then concatenate along the current axis
                 return _concat(arrays, axis=i)
 
-        return _recurse_all_charges()
+        array = _recurse_all_charges()
+
+        if permutations is not None:
+            for axis, permutation in enumerate(permutations):
+                permutation = ar.do("asarray", permutation, like=array)
+                array = ar.do("take", array, permutation, axis=axis)
+
+        return array
 
     def to_flat(self):
         """Convert this block sparse backend abelian or fermionic array to a

--- a/tests/test_flat/test_flat_abelian_array.py
+++ b/tests/test_flat/test_flat_abelian_array.py
@@ -5,6 +5,41 @@ import pytest
 import symmray as sr
 
 
+def test_to_dense_index_maps_roundtrip():
+    import numpy as np
+
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        array,
+        symmetry="Z2",
+        index_maps=index_maps,
+        duals=(False, True),
+        flat=True,
+    )
+    np.testing.assert_allclose(x.to_dense(index_maps=index_maps), array)
+
+
+@pytest.mark.parametrize("backend", ("numpy", "jax", "torch"))
+def test_to_dense_index_maps_backend(backend, require_backend):
+    import autoray as ar
+    import numpy as np
+
+    require_backend(backend)
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        array,
+        symmetry="Z2",
+        index_maps=index_maps,
+        duals=(False, True),
+        flat=True,
+    ).to(backend)
+    actual = x.to_dense(index_maps=index_maps)
+    assert ar.infer_backend(actual) == backend
+    np.testing.assert_allclose(ar.to_numpy(actual), array)
+
+
 def get_zn_blocksparse_flat_compat(
     symmetry,
     shape,

--- a/tests/test_flat/test_flat_fermionic_array.py
+++ b/tests/test_flat/test_flat_fermionic_array.py
@@ -10,6 +10,23 @@ from symmray.flat.flat_fermionic_array import (
 from .test_flat_abelian_array import get_zn_blocksparse_flat_compat
 
 
+def test_fermi_to_dense_index_maps_roundtrip():
+    import numpy as np
+
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        array,
+        symmetry="Z2",
+        index_maps=index_maps,
+        duals=(False, True),
+        fermionic=True,
+        flat=True,
+    )
+
+    np.testing.assert_allclose(x.to_dense(index_maps=index_maps), array)
+
+
 class TestConjProject:
     @pytest.mark.parametrize("dual0", (False, True))
     @pytest.mark.parametrize("dual1", (False, True))

--- a/tests/test_sparse/test_sparse_abelian_array.py
+++ b/tests/test_sparse/test_sparse_abelian_array.py
@@ -67,6 +67,65 @@ def test_AbelianArray_to_dense(symmetry):
     )
 
 
+@pytest.mark.parametrize(
+    "symmetry,index_map",
+    [
+        ("Z2", (0, 1, 1, 0)),
+        ("U1", (0, 1, 0, 1)),
+        ("U1U1", ((0, 0), (1, 0), (0, 0), (1, 0))),
+    ],
+)
+def test_AbelianArray_to_dense_index_maps_roundtrip(symmetry, index_map):
+    import numpy as np
+
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = (index_map, index_map)
+    x = sr.utils.from_dense(
+        array,
+        symmetry=symmetry,
+        index_maps=index_maps,
+        duals=(False, True),
+    )
+    assert_allclose(x.to_dense(index_maps=index_maps), array)
+
+
+def test_AbelianArray_to_dense_index_maps_default_packed_order():
+    import numpy as np
+
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        array,
+        symmetry="Z2",
+        index_maps=index_maps,
+        duals=(False, True),
+    )
+    assert_allclose(x.to_dense(), np.diag([1.0, 4.0, 2.0, 3.0]))
+
+
+@pytest.mark.parametrize(
+    "index_maps,match",
+    [
+        (((0, 1, 1, 0),), "Expected 2 index maps"),
+        (((0, 1, 1), (0, 1, 1, 0)), "axis 0 has length 3"),
+        (((0, 1, 1, 1), (0, 1, 1, 0)), "axis 0.*multiplicities"),
+        (((0, 1, 1, 2), (0, 1, 1, 0)), "axis 0.*multiplicities"),
+    ],
+)
+def test_AbelianArray_to_dense_index_maps_invalid(index_maps, match):
+    import numpy as np
+
+    valid_index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        np.eye(4),
+        symmetry="Z2",
+        index_maps=valid_index_maps,
+        duals=(False, True),
+    )
+    with pytest.raises(ValueError, match=match):
+        x.to_dense(index_maps=index_maps)
+
+
 @pytest.mark.parametrize("symmetry", all_symmetries)
 @pytest.mark.parametrize("missing", (False, True))
 @pytest.mark.parametrize("mode", ["insert", "concat"])

--- a/tests/test_sparse/test_sparse_fermionic_array.py
+++ b/tests/test_sparse/test_sparse_fermionic_array.py
@@ -6,6 +6,19 @@ import symmray as sr
 all_symmetries = ["Z2", "Z4", "U1"]
 
 
+def test_fermi_to_dense_index_maps_roundtrip():
+    array = np.diag([1.0, 2.0, 3.0, 4.0])
+    index_maps = ((0, 1, 1, 0),) * 2
+    x = sr.utils.from_dense(
+        array,
+        symmetry="Z2",
+        index_maps=index_maps,
+        duals=(False, True),
+        fermionic=True,
+    )
+    np.testing.assert_allclose(x.to_dense(index_maps=index_maps), array)
+
+
 class TestConjProject:
     @pytest.mark.parametrize("dual0", (False, True))
     @pytest.mark.parametrize("dual1", (False, True))


### PR DESCRIPTION
This PR adds an `index_maps` kwarg to `.to_dense()`, that matches the `from_dense` format. This allows one to easily construct a symmray array from a dense array, and then convert it back with compatible basis ordering, for testing or other purposes.