### PR TITLE
various fermionic upgrades including conj_project axes

### DIFF
--- a/docs/block_storage.md
+++ b/docs/block_storage.md
@@ -1,4 +1,4 @@
-# Storage backends
+# Block storage
 
 `symmray` has two storage layouts. Both can hold numerical blocks from NumPy,
 PyTorch, JAX, or another Autoray backend.

--- a/docs/block_storage.md
+++ b/docs/block_storage.md
@@ -25,13 +25,18 @@ shape `(num_blocks, *shape_block)`. Sector keys form a second array with shape
 `(num_blocks, ndim)`.
 
 All stored blocks must therefore have the same
-[`shape_block`](#symmray.flat.flat_data_common.FlatCommon.shape_block). In
-practice, each charge sector on an axis must have the same size. Flat storage
-is intended for cyclic symmetries. Its fixed-shape stacked arrays are designed
-for vectorized GPU execution and tracing or compilation, especially with
-[`jax.jit`](https://docs.jax.dev/en/latest/_autosummary/jax.jit.html) and
+[`shape_block`](#symmray.flat.flat_data_common.FlatCommon.shape_block).
+Equivalently, each charge sector on an axis must have the *same size*. Flat
+storage also requires all possible charge sectors to be present, which in
+practice mean using *cyclic symmetries*. Its fixed-shape stacked arrays are
+designed for vectorized GPU execution and tracing or compilation, especially
+with [`jax.jit`](https://docs.jax.dev/en/latest/_autosummary/jax.jit.html) and
 [`torch.compile`](https://docs.pytorch.org/docs/stable/generated/torch.compile.html).
 Block shapes and sector structure must remain static across compiled calls.
+
+For fermionic arrays, parity and phases are also handled in a branchless
+manner, allowing expressions involving dynamic parities, such as wavefunction
+amplitude contractions, to still be compiled and vectorized.
 
 [`Z2ArrayFlat`](#symmray.flat.flat_abelian_array.Z2ArrayFlat) and
 [`Z2FermionicArrayFlat`](#symmray.flat.flat_fermionic_array.Z2FermionicArrayFlat)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Release notes for `symmray`. See also the [GitHub releases page](https://github.
 **Enhancements:**
 
 - Fermionic arrays expose `dummy_parity`, the combined parity of their dummy modes, while preserving traced backend scalar types for flat arrays.
+- `phase_global(parity=...)` conditionally applies a global fermionic phase and supports traced parity scalars with the flat backend.
 
 ## v0.3.1 (2026-08-25)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 Release notes for `symmray`. See also the [GitHub releases page](https://github.com/jcmgray/symmray/releases).
 
+## v0.4.0 (unreleased)
+
+**Breaking Changes:**
+
+- `conj_project` now takes `axes=` instead of `axis=`. It accepts either a
+  single integer or an ordered sequence of axes to keep uncontracted.
+
 ## v0.3.1 (2026-08-25)
 
 **Enhancements:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,8 +6,11 @@ Release notes for `symmray`. See also the [GitHub releases page](https://github.
 
 **Breaking Changes:**
 
-- `conj_project` now takes `axes=` instead of `axis=`. It accepts either a
-  single integer or an ordered sequence of axes to keep uncontracted.
+- `conj_project` now takes `axes=` instead of `axis=`. It accepts either a single integer or an ordered sequence of axes to keep uncontracted.
+
+**Enhancements:**
+
+- Fermionic arrays expose `dummy_parity`, the combined parity of their dummy modes, while preserving traced backend scalar types for flat arrays.
 
 ## v0.3.1 (2026-08-25)
 

--- a/docs/dummy_modes.md
+++ b/docs/dummy_modes.md
@@ -39,7 +39,9 @@ x.dummy_modes
 ```
 
 The dummy mode is metadata. It does not add an array axis or change the block
-shapes.
+shapes. [`array.dummy_parity`](#FermionicCommon.dummy_parity) gives the
+combined parity of all dummy modes. For flat arrays it preserves backend scalar
+types, so it can be used inside traced or compiled computations.
 
 ## Contraction
 

--- a/docs/fermionic_arrays.md
+++ b/docs/fermionic_arrays.md
@@ -56,11 +56,12 @@ indices, the dual open indices of the conjugated network may need explicit
 phase flips.
 
 Use
-[`x.conj_project(axis=...)`](#symmray.fermionic_common.FermionicCommon.conj_project)
-when inserting an array together with its conjugate as a projector. `axis`
-selects the uncontracted bond. The method handles the dualities of every
-contracted axis and the global sign of odd-parity arrays for both sparse and
-flat storage.
+[`x.conj_project(axes=...)`](#symmray.fermionic_common.FermionicCommon.conj_project)
+when inserting an array together with its conjugate as a projector. `axes`
+accepts either one integer or an ordered sequence selecting the uncontracted
+bonds. The first selected axis sets the reference duality inherited when the
+open axes are fused. The method handles the dualities of every contracted axis
+and the global sign of odd-parity arrays for both sparse and flat storage.
 
 ![Conjugation with one open dual index that needs a phase flip](images/tn-conjugate-phase.png)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,5 +76,4 @@ x_torch = x.to("torch-float32-cuda:0")
 x_jax = x.to(backend="jax", dtype="complex128")
 ```
 
-This conversion is separate from choosing `symmray`'s sparse or flat
-[storage layout](storage_backends.md).
+This conversion is separate from choosing `symmray`'s sparse or flat [block storage](block storage.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ operators, and tensor-network helpers.
 installation.md
 getting_started.md
 abelian_arrays.md
-storage_backends.md
+block_storage.md
 fermionic_arrays.md
 dummy_modes.md
 fermionic_operators.md

--- a/symmray/array_common.py
+++ b/symmray/array_common.py
@@ -1139,6 +1139,41 @@ def without(it, remove):
     return tuple(el for i, el in enumerate(it) if i not in remove)
 
 
+def _normalize_axes(axes, ndim):
+    """Normalize a single axis or iterable of axes."""
+    if ar.is_scalar(axes):
+        axes = (axes,)
+    else:
+        try:
+            axes = tuple(axes)
+        except TypeError:
+            raise TypeError("axes must be an integer or iterable of integers")
+
+    if not axes:
+        raise ValueError("axes must contain at least one axis")
+
+    normalized_axes = []
+    for axis in axes:
+        try:
+            axis = operator.index(axis)
+        except TypeError:
+            raise TypeError("axes must contain only integers")
+
+        if axis < 0:
+            axis += ndim
+        if not 0 <= axis < ndim:
+            raise ValueError(
+                f"axis {axis} is out of bounds for an array with "
+                f"{ndim} dimensions"
+            )
+        normalized_axes.append(axis)
+
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("axes cannot contain duplicates")
+
+    return tuple(normalized_axes)
+
+
 def parse_tensordot_axes(axes, ndim_a, ndim_b):
     """Parse the axes argument for single integer and also negative indices.
     Returning the 4 axes groups that can be used for fusing.

--- a/symmray/bosonic_common.py
+++ b/symmray/bosonic_common.py
@@ -1,5 +1,6 @@
 """Common methods for any 'bosonic' (non-fermionic) arrays."""
 
+from .array_common import _normalize_axes
 from .linalg_common import Absorb
 
 
@@ -56,14 +57,14 @@ class BosonicCommon:
         """
         return self._conj_abelian(inplace=inplace)
 
-    def conj_project(self, axis=-1, inplace=False) -> "BosonicCommon":
+    def conj_project(self, axes=-1, inplace=False) -> "BosonicCommon":
         """Conjugate this array for use with itself as a projector.
 
         Parameters
         ----------
-        axis : int, optional
-            The axis carrying the uncontracted bond. This has no effect for
-            bosonic arrays.
+        axes : int or sequence of int, optional
+            The axes carrying the uncontracted bonds. This has no effect for
+            bosonic arrays apart from validating the axes.
         inplace : bool, optional
             Whether to perform the operation inplace or return a new array.
 
@@ -71,6 +72,7 @@ class BosonicCommon:
         -------
         BosonicCommon
         """
+        _normalize_axes(axes, self.ndim)
         return self.conj(inplace=inplace)
 
     def dagger(self, inplace=False) -> "BosonicCommon":
@@ -90,12 +92,12 @@ class BosonicCommon:
 
     def dagger_project_left(self, inplace=False) -> "BosonicCommon":
         """Return the adjoint for use as a left projector."""
-        new = self.conj_project(axis=-1, inplace=inplace)
+        new = self.conj_project(axes=-1, inplace=inplace)
         return new.transpose(inplace=True)
 
     def dagger_project_right(self, inplace=False) -> "BosonicCommon":
         """Return the adjoint for use as a right projector."""
-        new = self.conj_project(axis=0, inplace=inplace)
+        new = self.conj_project(axes=0, inplace=inplace)
         return new.transpose(inplace=True)
 
     dagger_compose_left = dagger

--- a/symmray/fermionic_common.py
+++ b/symmray/fermionic_common.py
@@ -2,7 +2,7 @@
 
 import autoray as ar
 
-from .array_common import parse_tensordot_axes
+from .array_common import _normalize_axes, parse_tensordot_axes
 from .fermionic_local_operators import FermionicOperator
 from .linalg_common import Absorb
 
@@ -443,7 +443,7 @@ class FermionicCommon:
         operator.
         """
         new = self.dagger()
-        return new._phase_project_fermionic(0, inplace=True)
+        return new._phase_project_fermionic((0,), inplace=True)
 
     def dagger_compose_right(self) -> "FermionicCommon":
         """Take the dagger (conjugate transpose) of this fermionic array,
@@ -462,18 +462,20 @@ class FermionicCommon:
         operator.
         """
         new = self.dagger()
-        return new._phase_project_fermionic(new.ndim - 1, inplace=True)
+        return new._phase_project_fermionic((new.ndim - 1,), inplace=True)
 
-    def conj_project(self, axis=-1, inplace=False) -> "FermionicCommon":
+    def conj_project(self, axes=-1, inplace=False) -> "FermionicCommon":
         """Conjugate this array for use with itself as a projector.
 
-        The selected axis carries the uncontracted bond. All other axes are
-        contracted back into the tensor network.
+        The selected axes carry the uncontracted bonds. All other axes are
+        contracted back into the tensor network. The first selected axis
+        sets the reference duality for the fermionic phase correction.
 
         Parameters
         ----------
-        axis : int, optional
-            The axis carrying the uncontracted bond.
+        axes : int or sequence of int, optional
+            The axes carrying the uncontracted bonds. A single integer can be
+            supplied when keeping one axis.
         inplace : bool, optional
             Whether to perform the operation inplace or return a new array.
 
@@ -481,16 +483,9 @@ class FermionicCommon:
         -------
         FermionicCommon
         """
-        if axis < 0:
-            axis += self.ndim
-        if not 0 <= axis < self.ndim:
-            raise ValueError(
-                f"axis {axis} is out of bounds for an array with "
-                f"{self.ndim} dimensions"
-            )
-
+        axes = _normalize_axes(axes, self.ndim)
         new = self.conj(inplace=inplace)
-        return new._phase_project_fermionic(axis, inplace=True)
+        return new._phase_project_fermionic(axes, inplace=True)
 
     def allclose(self, other, **kwargs):
         """Check if two fermionic arrays are element-wise equal within a

--- a/symmray/fermionic_common.py
+++ b/symmray/fermionic_common.py
@@ -62,6 +62,11 @@ class FermionicCommon:
         """
         return self._dummy_modes
 
+    @property
+    def dummy_parity(self):
+        """The combined parity of the dummy modes."""
+        return sum(mode.parity for mode in self.dummy_modes) % 2
+
     def _binary_blockwise_op(self, other, fn, inplace=False, **kwargs):
         """Need to sync phases before performing blockwise operations.
 

--- a/symmray/flat/flat_fermionic_array.py
+++ b/symmray/flat/flat_fermionic_array.py
@@ -652,20 +652,25 @@ class FermionicArrayFlat(
             "Flat fermionic arrays do not support individual sector phasing."
         )
 
-    def phase_global(self, inplace=False):
-        """Flip the global phase of the array.
+    def phase_global(self, inplace=False, *, parity=1):
+        """Flip the global phase of the array, optionally conditioned on a
+        given `parity`.
 
         Parameters
         ----------
         inplace : bool, optional
             Whether to perform the operation in place.
+        parity : scalar, optional
+            Flip the phase when this is odd, and leave it unchanged when this
+            is even. This may be a traced backend scalar.
 
         Returns
         -------
-        FermionicArray
+        FermionicArrayFlat
         """
         new = self if inplace else self.copy()
-        new.modify(phases=-new.phases)
+        phase_change = (parity % 2) * -2 + 1
+        new.modify(phases=new.phases * phase_change)
         return new
 
     def _resolve_dummy_modes_conj(self, phase_permutation=True):

--- a/symmray/flat/flat_fermionic_array.py
+++ b/symmray/flat/flat_fermionic_array.py
@@ -691,8 +691,7 @@ class FermionicArrayFlat(
             # | Pn-1 Pn-2 ... P1 P0 | on-1 on-2 ... o1 o0 |
             #                     <--
             # | on-1 on-2 ... o1 o0 | Pn-1 Pn-2 ... P1 P0 |
-            dummy_parity = sum(m.parity for m in self.dummy_modes) % 2
-            sign = (self.parity * dummy_parity) * -2 + 1
+            sign = (self.parity * self.dummy_parity) * -2 + 1
             self.modify(phases=self.phases * sign)
 
     def _resolve_dummy_modes_combine(self, a, b):
@@ -712,8 +711,7 @@ class FermionicArrayFlat(
         # 1. initially we have:
         # l-dummy modes | l-real modes | r-dummy modes | r-real modes
         # so calc phase from moving r-dummy modes past l-real modes
-        r_dummy_parity = sum(m.parity for m in r_dummy_modes) % 2
-        phase = (a.parity * r_dummy_parity) * -2 + 1
+        phase = (a.parity * b.dummy_parity) * -2 + 1
 
         # 2. sort the merged dummy modes into canonical label order; the
         # fermionic sign of that sort is the Koszul sign (computed vectorized,
@@ -867,7 +865,7 @@ class FermionicArrayFlat(
         )
 
         # a dual reference also picks up the parity of any dummy modes
-        const = reference_dual * sum(mode.parity for mode in new.dummy_modes)
+        const = reference_dual * new.dummy_parity
         exponents = ar.do(
             "matmul",
             new._sectors % 2,

--- a/symmray/flat/flat_fermionic_array.py
+++ b/symmray/flat/flat_fermionic_array.py
@@ -844,29 +844,30 @@ class FermionicArrayFlat(
 
         return new
 
-    def _phase_project_fermionic(self, axis, inplace=False):
+    def _phase_project_fermionic(self, axes, inplace=False):
         """Apply the phase-only correction for a fermionic projector.
 
         ``conj_project`` calls this after ``conj``. The dagger projector
-        wrappers call it after ``dagger``, using the bond axis after reversal.
-        Thus ``axis`` must be normalized for the current array and identifies
-        the only axis not contracted back into the tensor network.
+        wrappers call it after ``dagger``, using the bond axes after reversal.
+        Thus ``axes`` must be normalized for the current array and identifies
+        the axes not contracted back into the tensor network.
         """
         new = self if inplace else self.copy()
-        bond_dual = new.indices[axis].dual
+        reference_dual = new.indices[axes[0]].dual
+        kept_axes = set(axes)
 
-        # contracted axes matching the bond duality contribute their parity
+        # contracted axes matching the reference duality contribute parity
         mask = ar.do(
             "asarray",
             tuple(
-                int((ax != axis) and (ix.dual is bond_dual))
+                int((ax not in kept_axes) and (ix.dual is reference_dual))
                 for ax, ix in enumerate(new.indices)
             ),
             like=new._sectors,
         )
 
-        # a dual bond also picks up the parity of any dummy modes
-        const = bond_dual * sum(mode.parity for mode in new.dummy_modes)
+        # a dual reference also picks up the parity of any dummy modes
+        const = reference_dual * sum(mode.parity for mode in new.dummy_modes)
         exponents = ar.do(
             "matmul",
             new._sectors % 2,

--- a/symmray/sparse/sparse_fermionic_array.py
+++ b/symmray/sparse/sparse_fermionic_array.py
@@ -412,9 +412,7 @@ class FermionicArray(
         new_dummy_modes = tuple(r.dag for r in reversed(self.dummy_modes))
         self.modify(dummy_modes=new_dummy_modes)
 
-        dummy_parity = sum(m.parity for m in new_dummy_modes) % 2
-
-        if phase_permutation and self.parity and dummy_parity:
+        if phase_permutation and self.parity and self.dummy_parity:
             # 2. moving dummy_modes charges back to left
             # after flipping might generate global sign
             # | Pn-1 Pn-2 ... P1 P0 | on-1 on-2 ... o1 o0 |
@@ -437,8 +435,7 @@ class FermionicArray(
         dummy_modes = [*l_dummy_modes, *r_dummy_modes]
 
         # e.g. (1, 2, 4, 5) + (3, 6, 7) -> [1, 2, 4, 5, 3, 6, 7]
-        r_dummy_parity = sum(m.parity for m in r_dummy_modes) % 2
-        if left.parity and r_dummy_parity:
+        if left.parity and right.dummy_parity:
             # moving r-dummy_modes charges over l-sectors generates sign
             phase = -1
         else:
@@ -662,7 +659,7 @@ class FermionicArray(
         )
 
         # a dual reference also picks up the parity of any dummy modes
-        const = reference_dual * sum(mode.parity for mode in new.dummy_modes)
+        const = reference_dual * new.dummy_parity
         phases = new.phases.copy()
 
         for sector in new.sectors:

--- a/symmray/sparse/sparse_fermionic_array.py
+++ b/symmray/sparse/sparse_fermionic_array.py
@@ -365,19 +365,25 @@ class FermionicArray(
             new._phases[sector] = -1
         return new
 
-    def phase_global(self, inplace=False):
-        """Flip the global phase of the array.
+    def phase_global(self, inplace=False, *, parity=1):
+        """Flip the global phase of the array, optionally conditioned on a
+        given `parity`.
 
         Parameters
         ----------
         inplace : bool, optional
             Whether to perform the operation in place.
+        parity : scalar, optional
+            Flip the phase when this is odd, and leave it unchanged when this
+            is even.
 
         Returns
         -------
         FermionicArray
         """
         new = self if inplace else self.copy()
+        if parity % 2 == 0:
+            return new
         for sector in new.sectors:
             phase = -new.phases.pop(sector, 1)
             if phase == -1:

--- a/symmray/sparse/sparse_fermionic_array.py
+++ b/symmray/sparse/sparse_fermionic_array.py
@@ -642,26 +642,27 @@ class FermionicArray(
 
         return new
 
-    def _phase_project_fermionic(self, axis, inplace=False):
+    def _phase_project_fermionic(self, axes, inplace=False):
         """Apply the phase-only correction for a fermionic projector.
 
         ``conj_project`` calls this after ``conj``. The dagger projector
-        wrappers call it after ``dagger``, using the bond axis after reversal.
-        Thus ``axis`` must be normalized for the current array and identifies
-        the only axis not contracted back into the tensor network.
+        wrappers call it after ``dagger``, using the bond axes after reversal.
+        Thus ``axes`` must be normalized for the current array and identifies
+        the axes not contracted back into the tensor network.
         """
         new = self if inplace else self.copy()
-        bond_dual = new.indices[axis].dual
+        reference_dual = new.indices[axes[0]].dual
+        kept_axes = set(axes)
 
-        # contracted axes matching the bond duality contribute their parity
+        # contracted axes matching the reference duality contribute parity
         axes_flip = tuple(
             ax
             for ax, ix in enumerate(new.indices)
-            if (ax != axis) and (ix.dual is bond_dual)
+            if (ax not in kept_axes) and (ix.dual is reference_dual)
         )
 
-        # a dual bond also picks up the parity of any dummy modes
-        const = bond_dual * sum(mode.parity for mode in new.dummy_modes)
+        # a dual reference also picks up the parity of any dummy modes
+        const = reference_dual * sum(mode.parity for mode in new.dummy_modes)
         phases = new.phases.copy()
 
         for sector in new.sectors:

--- a/tests/test_flat/test_flat_abelian_array.py
+++ b/tests/test_flat/test_flat_abelian_array.py
@@ -78,7 +78,7 @@ class TestConjProject:
             seed=42,
         )
         expected = x.conj()
-        actual = x.conj_project(axis=1)
+        actual = x.conj_project(axes=(0, 2))
         actual.test_allclose(expected)
 
     def test_inplace(self):
@@ -90,7 +90,7 @@ class TestConjProject:
             seed=42,
         )
         expected = x.conj()
-        actual = x.conj_project(axis=1, inplace=True)
+        actual = x.conj_project(axes=(0, 2), inplace=True)
         assert actual is x
         actual.test_allclose(expected)
 

--- a/tests/test_flat/test_flat_fermionic_array.py
+++ b/tests/test_flat/test_flat_fermionic_array.py
@@ -32,7 +32,7 @@ class TestConjProject:
     @pytest.mark.parametrize("dual1", (False, True))
     @pytest.mark.parametrize("dual2", (False, True))
     @pytest.mark.parametrize("charge", (0, 1))
-    @pytest.mark.parametrize("axis", (0, 1, -1))
+    @pytest.mark.parametrize("axes", (0, (0,), (0, 2), (2, 0), (0, -2)))
     @pytest.mark.parametrize("inplace", (False, True))
     def test_matches_sparse(
         self,
@@ -40,7 +40,7 @@ class TestConjProject:
         dual1,
         dual2,
         charge,
-        axis,
+        axes,
         inplace,
     ):
         sparse = get_zn_blocksparse_flat_compat(
@@ -53,10 +53,10 @@ class TestConjProject:
             seed=42,
         )
         sparse.randomize_phases(43, inplace=True)
-        expected = sparse.conj_project(axis=axis)
+        expected = sparse.conj_project(axes=axes)
         flat = sparse.to_flat()
 
-        actual = flat.conj_project(axis=axis, inplace=inplace)
+        actual = flat.conj_project(axes=axes, inplace=inplace)
         assert (actual is flat) is inplace
         actual.check()
         actual.to_blocksparse().test_allclose(expected)
@@ -74,9 +74,9 @@ class TestConjProject:
             seed=42,
         )
         sparse.randomize_phases(43, inplace=True)
-        expected = sparse.conj_project(axis=1)
+        expected = sparse.conj_project(axes=(1, 2))
 
-        actual = sparse.to_flat().to(backend).conj_project(axis=1)
+        actual = sparse.to_flat().to(backend).conj_project(axes=(1, 2))
         assert actual.backend == backend
         actual.check()
         actual.to("numpy").to_blocksparse().test_allclose(expected)

--- a/tests/test_flat/test_flat_fermionic_array.py
+++ b/tests/test_flat/test_flat_fermionic_array.py
@@ -27,6 +27,40 @@ def test_fermi_to_dense_index_maps_roundtrip():
     np.testing.assert_allclose(x.to_dense(index_maps=index_maps), array)
 
 
+def test_dummy_parity_under_jit():
+    jax = pytest.importorskip("jax")
+    import jax.numpy as jnp
+
+    x = sr.utils.get_rand("Z2", (2,), fermionic=True, flat=True, seed=42)
+
+    def f(parities):
+        y = x.copy()
+        y._dummy_modes = tuple(
+            FermionicOperator(k, parity=parities[k]) for k in range(3)
+        )
+        return y.dummy_parity
+
+    assert int(jax.jit(f)(jnp.asarray((1, 0, 1)))) == 0
+    assert int(jax.jit(f)(jnp.asarray((1, 0, 0)))) == 1
+
+
+def test_dummy_parity_under_torch_compile():
+    torch = pytest.importorskip("torch")
+
+    x = sr.utils.get_rand("Z2", (2,), fermionic=True, flat=True, seed=42)
+
+    def f(parities):
+        y = x.copy()
+        y._dummy_modes = tuple(
+            FermionicOperator(k, parity=parities[k]) for k in range(3)
+        )
+        return y.dummy_parity
+
+    compiled_f = torch.compile(f, fullgraph=True)
+    assert int(compiled_f(torch.tensor((1, 0, 1)))) == 0
+    assert int(compiled_f(torch.tensor((1, 0, 0)))) == 1
+
+
 class TestConjProject:
     @pytest.mark.parametrize("dual0", (False, True))
     @pytest.mark.parametrize("dual1", (False, True))

--- a/tests/test_flat/test_flat_fermionic_array.py
+++ b/tests/test_flat/test_flat_fermionic_array.py
@@ -264,7 +264,9 @@ def test_phase_transpose(
 @pytest.mark.parametrize("symmetry", ["Z2", "Z4"])
 @pytest.mark.parametrize("charge", [0, 1])
 @pytest.mark.parametrize("seed", [42, 43, 44])
-def test_phase_global(symmetry, charge, seed):
+@pytest.mark.parametrize("parity", [0, 1, 2, 3])
+@pytest.mark.parametrize("inplace", [False, True])
+def test_phase_global(symmetry, charge, seed, parity, inplace):
     x = get_zn_blocksparse_flat_compat(
         symmetry,
         (2, 4, 6),
@@ -276,8 +278,46 @@ def test_phase_global(symmetry, charge, seed):
     # add some non-trivial phases
     x.randomize_phases(seed + 1, inplace=True)
     fx = x.to_flat()
-    fxg = fx.phase_global()
-    fxg.to_blocksparse().test_allclose(x.phase_global())
+    fxg = fx.phase_global(parity=parity, inplace=inplace)
+    assert (fxg is fx) is inplace
+    fxg.to_blocksparse().test_allclose(x.phase_global(parity=parity))
+
+
+def test_phase_global_under_jit():
+    jax = pytest.importorskip("jax")
+    import jax.numpy as jnp
+
+    x = (
+        get_zn_blocksparse_flat_compat("Z2", (2, 4), fermionic=True, seed=42)
+        .to_flat()
+        .to("jax")
+    )
+    phases = x.phases
+
+    def f(parity):
+        return x.phase_global(parity=parity).phases
+
+    compiled_f = jax.jit(f)
+    assert bool(jnp.all(compiled_f(jnp.asarray(0)) == phases))
+    assert bool(jnp.all(compiled_f(jnp.asarray(1)) == -phases))
+
+
+def test_phase_global_under_torch_compile():
+    torch = pytest.importorskip("torch")
+
+    x = (
+        get_zn_blocksparse_flat_compat("Z2", (2, 4), fermionic=True, seed=42)
+        .to_flat()
+        .to("torch")
+    )
+    phases = x.phases
+
+    def f(parity):
+        return x.phase_global(parity=parity).phases
+
+    compiled_f = torch.compile(f, fullgraph=True)
+    assert bool(torch.all(compiled_f(torch.tensor(0)) == phases))
+    assert bool(torch.all(compiled_f(torch.tensor(1)) == -phases))
 
 
 @pytest.mark.parametrize("symmetry", ["Z2", "Z4"])

--- a/tests/test_sparse/test_sparse_abelian_array.py
+++ b/tests/test_sparse/test_sparse_abelian_array.py
@@ -37,15 +37,20 @@ class TestConjProject:
     def test_matches_conj(self):
         x = sr.utils.get_rand("Z2", (2, 3, 4), seed=42)
         expected = x.conj()
-        actual = x.conj_project(axis=1)
+        actual = x.conj_project(axes=(0, 2))
         actual.test_allclose(expected)
 
     def test_inplace(self):
         x = sr.utils.get_rand("Z2", (2, 3, 4), seed=42)
         expected = x.conj()
-        actual = x.conj_project(axis=1, inplace=True)
+        actual = x.conj_project(axes=(0, 2), inplace=True)
         assert actual is x
         actual.test_allclose(expected)
+
+    def test_invalid_axes(self):
+        x = sr.utils.get_rand("Z2", (2, 3, 4), seed=42)
+        with pytest.raises(ValueError, match="duplicates"):
+            x.conj_project(axes=(0, -3))
 
 
 all_symmetries = ("Z2", "Z3", "Z5", "U1", "Z2Z2", "U1U1")

--- a/tests/test_sparse/test_sparse_fermionic_array.py
+++ b/tests/test_sparse/test_sparse_fermionic_array.py
@@ -24,7 +24,17 @@ class TestConjProject:
     @pytest.mark.parametrize("dual1", (False, True))
     @pytest.mark.parametrize("dual2", (False, True))
     @pytest.mark.parametrize("charge", (0, 1))
-    @pytest.mark.parametrize("axis", (0, 1, -1))
+    @pytest.mark.parametrize(
+        "axes",
+        (
+            0,
+            (0,),
+            (0, 2),
+            (2, 0),
+            (0, -2),
+            (0, 1, 2),
+        ),
+    )
     @pytest.mark.parametrize("inplace", (False, True))
     def test_phase_rule(
         self,
@@ -32,7 +42,7 @@ class TestConjProject:
         dual1,
         dual2,
         charge,
-        axis,
+        axes,
         inplace,
     ):
         x = sr.utils.get_rand(
@@ -49,29 +59,49 @@ class TestConjProject:
         original = x.copy()
 
         expected = original.conj()
-        normalized_axis = axis % expected.ndim
-        bond_dual = expected.indices[normalized_axis].dual
+        if isinstance(axes, int):
+            normalized_axes = (axes % expected.ndim,)
+        else:
+            normalized_axes = tuple(ax % expected.ndim for ax in axes)
+        reference_dual = expected.indices[normalized_axes[0]].dual
         axes_flip = tuple(
             ax
             for ax, ix in enumerate(expected.indices)
-            if (ax != normalized_axis) and (ix.dual is bond_dual)
+            if (ax not in normalized_axes) and (ix.dual is reference_dual)
         )
         expected.phase_flip(*axes_flip, inplace=True)
-        if bond_dual and sum(mode.parity for mode in expected.dummy_modes) % 2:
+        dummy_parity = sum(mode.parity for mode in expected.dummy_modes)
+        if reference_dual and dummy_parity % 2:
             expected.phase_global(inplace=True)
 
-        actual = x.conj_project(axis=axis, inplace=inplace)
+        actual = x.conj_project(axes=axes, inplace=inplace)
         assert (actual is x) is inplace
         actual.check()
         actual.test_allclose(expected)
         if not inplace:
             x.test_allclose(original)
 
-    @pytest.mark.parametrize("axis", (-4, 3))
-    def test_invalid_axis(self, axis):
+    @pytest.mark.parametrize(
+        "axes, match",
+        (
+            (-4, "out of bounds"),
+            (3, "out of bounds"),
+            ((), "at least one"),
+            ((0, 3), "out of bounds"),
+            ((0, -3), "duplicates"),
+            ((0, 0), "duplicates"),
+        ),
+    )
+    def test_invalid_axes(self, axes, match):
         x = sr.utils.get_rand("Z2", (2, 2, 2), fermionic=True, seed=42)
-        with pytest.raises(ValueError, match="out of bounds"):
-            x.conj_project(axis=axis)
+        with pytest.raises(ValueError, match=match):
+            x.conj_project(axes=axes)
+
+    @pytest.mark.parametrize("axes", (None, 1.5, (0, 1.5)))
+    def test_invalid_axes_type(self, axes):
+        x = sr.utils.get_rand("Z2", (2, 2, 2), fermionic=True, seed=42)
+        with pytest.raises(TypeError, match="integer"):
+            x.conj_project(axes=axes)
 
 
 @pytest.mark.parametrize("symmetry", all_symmetries)

--- a/tests/test_sparse/test_sparse_fermionic_array.py
+++ b/tests/test_sparse/test_sparse_fermionic_array.py
@@ -2,8 +2,24 @@ import numpy as np
 import pytest
 
 import symmray as sr
+from symmray.fermionic_local_operators import FermionicOperator
 
 all_symmetries = ["Z2", "Z4", "U1"]
+
+
+@pytest.mark.parametrize(
+    "parities, expected",
+    (((), 0), ((1,), 1), ((1, 1), 0), ((0, 1, 0), 1)),
+)
+def test_dummy_parity(parities, expected):
+    x = sr.utils.get_rand("Z2", (2,), fermionic=True, seed=42)
+    x.modify(
+        dummy_modes=tuple(
+            FermionicOperator(k, parity=parity)
+            for k, parity in enumerate(parities)
+        )
+    )
+    assert x.dummy_parity == expected
 
 
 def test_fermi_to_dense_index_maps_roundtrip():
@@ -70,8 +86,7 @@ class TestConjProject:
             if (ax not in normalized_axes) and (ix.dual is reference_dual)
         )
         expected.phase_flip(*axes_flip, inplace=True)
-        dummy_parity = sum(mode.parity for mode in expected.dummy_modes)
-        if reference_dual and dummy_parity % 2:
+        if reference_dual and expected.dummy_parity:
             expected.phase_global(inplace=True)
 
         actual = x.conj_project(axes=axes, inplace=inplace)

--- a/tests/test_sparse/test_sparse_fermionic_array.py
+++ b/tests/test_sparse/test_sparse_fermionic_array.py
@@ -22,6 +22,22 @@ def test_dummy_parity(parities, expected):
     assert x.dummy_parity == expected
 
 
+@pytest.mark.parametrize("parity", [0, 1, 2, 3])
+@pytest.mark.parametrize("inplace", [False, True])
+def test_phase_global_conditional(parity, inplace):
+    x = sr.utils.get_rand("Z2", (2, 4), fermionic=True, seed=42)
+    x.randomize_phases(43, inplace=True)
+    original = x.copy()
+    expected = original.phase_global() if parity % 2 else original
+
+    actual = x.phase_global(parity=parity, inplace=inplace)
+
+    assert (actual is x) is inplace
+    actual.test_allclose(expected)
+    if not inplace:
+        x.test_allclose(original)
+
+
 def test_fermi_to_dense_index_maps_roundtrip():
     array = np.diag([1.0, 2.0, 3.0, 4.0])
     index_maps = ((0, 1, 1, 0),) * 2

--- a/tests/test_sparse/test_sparse_fermionic_linalg.py
+++ b/tests/test_sparse/test_sparse_fermionic_linalg.py
@@ -759,8 +759,8 @@ def test_svd_projector_identity(symm, seed):
     vhdag = vh.dagger_project_right().unfuse_all()
     u = u.unfuse_all()
     vh = vh.unfuse_all()
-    uconj = u.conj_project(axis=-1)
-    vhconj = vh.conj_project(axis=0)
+    uconj = u.conj_project(axes=-1)
+    vhconj = vh.conj_project(axes=0)
 
     zl = ctg.einsum("abc,dec,defg->abfg", u, uconj, x)
     zl.test_allclose(x)


### PR DESCRIPTION
This PR adds a few convenience functions for manipulating fermionic arrays.

- `conj_project`: now takes a `axes` rather than `axis` kwarg, allowing for multiple axes to be defined as forming the effective projector (breaking)
- fermionic arrays now have a `dummy_parity` attribute, which is simply the combined parity of all dummy modes
- `phase_global` now has a `parity` kwarg, which conditions the phasing on an actual parity, suitable for branchless/traced computations with flat storage