### PR TITLE
update sparse decomposition max_bond handling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ Release notes for `symmray`. See also the [GitHub releases page](https://github.
 
 - Fermionic arrays expose `dummy_parity`, the combined parity of their dummy modes, while preserving traced backend scalar types for flat arrays.
 - `phase_global(parity=...)` conditionally applies a global fermionic phase and supports traced parity scalars with the flat backend.
+- Sparse {func}`~symmray.linalg.svd_rand_truncated`: spread finite `max_bond` over charge sectors in proportion to their current sizes *before* computing block decompositions (otherwise no speedup) and also supports abs and rel cutoffs.
+- Sparse truncated SVD and eigendecomposition accept `max_bond_mode="eager"` for the same size-based allocation. Their default `max_bond_mode="global"` now selects the largest values across full block spectra even when `cutoff=0.0`, preserving degenerate multiplets that cross the threshold.
+- Truncated SVD and eigendecomposition methods now default to `cutoff_mode="rel"`.
 
 ## v0.3.1 (2026-08-25)
 

--- a/docs/linear_algebra.md
+++ b/docs/linear_algebra.md
@@ -3,8 +3,11 @@
 `symmray` applies linear algebra block by block while preserving charge and
 fermionic metadata.
 
-The decomposition routines currently use
-[`quimb`](https://quimb.readthedocs.io/) and require it to be installed.
+The decomposition routines currently use the
+[`array_split`](https://quimb.readthedocs.io/en/latest/autoapi/quimb/tensor/decomp/index.html#quimb.tensor.decomp.array_split)
+function from [`quimb`](https://quimb.readthedocs.io/) and require it to be
+installed.
+
 
 ## Standard decompositions
 
@@ -41,14 +44,16 @@ SVD and eigendecomposition return their spectrum as a
 charges to one-dimensional blocks and can be applied with
 [`multiply_diagonal`](#symmray.interface.multiply_diagonal).
 
+
 ## Tensor-network variants
 
 The following variants trade accuracy, stability, or setup cost for properties
 useful in tensor-network calculations:
 
-- [`svd_truncated`](#symmray.linalg.svd_truncated) and
-  [`eigh_truncated`](#symmray.linalg.eigh_truncated) truncate by `max_bond`,
+- [`svd_truncated`](#symmray.linalg.svd_truncated) truncate by `max_bond`,
   `cutoff`, and `cutoff_mode`
+- [`eigh_truncated`](#symmray.linalg.eigh_truncated) the same for an assumed
+  Hermitian matrix
 - [`svd_rand_truncated`](#symmray.linalg.svd_rand_truncated) uses a randomized
   low-rank approximation
 - [`svd_via_eig_truncated`](#symmray.linalg.svd_via_eig_truncated) computes an
@@ -61,11 +66,55 @@ useful in tensor-network calculations:
   Cholesky factorization
 
 Decompositions with singular or eigenvalues accept `absorb` to control where
-the spectrum is placed. For example, `absorb="left"` returns an isometric right
-factor.
+the spectrum is 'placed'. For example, `absorb="left"` returns an isometric
+right factor.
 
-The sparse and flat layouts share this interface. Their numerical behavior can
-differ because flat algorithms operate on stacked blocks.
+The integer value or any of its listed string aliases can be supplied:
+
+| `absorb` value | String aliases | Returned factors |
+| --- | --- | --- |
+| `None` | `"U,s,VH"` | `U`, `s`, and `VH` separately |
+| `2` | `"s"` | `s` only |
+| `-12` | `"lsqrt"` | `U * sqrt(s)` only |
+| `-11` | `"VH"`, `"rorthog"` | `VH` only |
+| `-10` | `"Us"`, `"lfactor"` | `U * s` only |
+| `-1` | `"Us,VH"`, `"left"` | `U * s` and `VH` |
+| `0` | `"Usq,sqVH"`, `"both"` | `U * sqrt(s)` and `sqrt(s) * VH` |
+| `1` | `"U,sVH"`, `"right"` | `U` and `s * VH` |
+| `10` | `"U"`, `"lorthog"` | `U` only |
+| `11` | `"sVH"`, `"rfactor"` | `s * VH` only |
+| `12` | `"sqVH"`, `"rsqrt"` | `sqrt(s) * VH` only |
+
+In many cases, specifying the minimally required `absorb` allows various faster
+shortcuts.
+
+
+## Sector truncation
+
+Sparse truncated decompositions accept `max_bond_mode`. With `"global"`, all
+block spectra are computed before the largest values are selected globally.
+This is the default for exact SVD and eigendecomposition. A degenerate
+multiplet crossing the threshold is kept whole, so the resulting bond may
+slightly exceed `max_bond`.
+
+The default `cutoff_mode="rel"` truncates values relative to the largest value
+across all retained sectors.
+
+With `max_bond_mode="eager"`, `max_bond` is spread over charge sectors in
+proportion to their current sizes *before* the block decompositions are
+computed. Each sector receives at least one mode when `max_bond` allows;
+otherwise the largest sectors are retained. This is the default for
+[`svd_rand_truncated`](#symmray.linalg.svd_rand_truncated), since otherwise
+there is no low-rank speedup. An `abs` or `rel` cutoff can further truncate the
+retained spectra globally. Cumulative cutoff modes and renormalization are not
+compatible with eager mode because they require the discarded spectra.
+
+For flat arrays, both `max_bond_mode` values currently use the equivalent of
+`"eager"` truncation. Their sectors have uniform sizes by construction, so
+`max_bond` is divided uniformly across the stacked blocks before decomposition.
+
+
+## Fermionic arrays
 
 For fermionic arrays, [`eigh_truncated`](#symmray.linalg.eigh_truncated) and
 Cholesky factorizations drop `dummy_modes` and the array label from returned

--- a/symmray/array_common.py
+++ b/symmray/array_common.py
@@ -676,12 +676,13 @@ class ArrayCommon:
 
     def eigh_truncated(
         self,
-        cutoff=-1.0,
-        cutoff_mode="rsum2",
+        cutoff=0.0,
+        cutoff_mode="rel",
         max_bond=-1,
         absorb=0,
         renorm=False,
         positive=False,
+        max_bond_mode="global",
         **kwargs,
     ) -> tuple["ArrayCommon", VectorCommon, "ArrayCommon"]:
         """Truncated hermitian eigen-decomposition of this assumed hermitian
@@ -690,9 +691,9 @@ class ArrayCommon:
         Parameters
         ----------
         cutoff : float, optional
-            Absolute eigenvalue cutoff threshold.
+            Absolute eigenvalue cutoff threshold. Default is 0.0.
         cutoff_mode : int or str, optional
-            How to perform the truncation:
+            How to perform the truncation. Defaults to ``"rel"``:
 
             - 1 or 'abs': trim values below ``cutoff``
             - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -703,6 +704,14 @@ class ArrayCommon:
 
         max_bond : int
             An explicit maximum bond dimension, use -1 for none.
+        max_bond_mode : {"global", "eager"}, optional
+            How to apply ``max_bond`` to sparse arrays. ``"global"`` computes
+            all block spectra before selecting values globally. ``"eager"``
+            spreads the bond dimension over sectors in proportion to their
+            current sizes before computing each block. Global mode keeps a
+            degenerate multiplet whole and may therefore exceed ``max_bond``.
+            Eager mode supports only absolute and relative cutoffs without
+            renormalization.
         absorb : {-1, 0, 1, None}
             How to absorb the eigenvalues.
 
@@ -734,6 +743,7 @@ class ArrayCommon:
         kwargs.setdefault("absorb", absorb)
         kwargs.setdefault("renorm", renorm)
         kwargs.setdefault("positive", positive)
+        kwargs.setdefault("max_bond_mode", max_bond_mode)
         return self._split(**kwargs)
 
     def svd(
@@ -759,10 +769,11 @@ class ArrayCommon:
     def svd_truncated(
         self,
         cutoff=0.0,
-        cutoff_mode="rsum2",
+        cutoff_mode="rel",
         max_bond=None,
         absorb="both",
         renorm=False,
+        max_bond_mode="global",
         **kwargs,
     ) -> tuple["ArrayCommon", VectorCommon, "ArrayCommon"]:
         """Truncated singular value decomposition of this array.
@@ -772,7 +783,7 @@ class ArrayCommon:
         cutoff : float, optional
             Singular value cutoff threshold.
         cutoff_mode : int or str, optional
-            How to perform the truncation:
+            How to perform the truncation. Defaults to ``"rel"``:
 
             - 1 or 'abs': trim values below ``cutoff``
             - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -783,6 +794,14 @@ class ArrayCommon:
 
         max_bond : int
             An explicit maximum bond dimension, use -1 for none.
+        max_bond_mode : {"global", "eager"}, optional
+            How to apply ``max_bond`` to sparse arrays. ``"global"`` computes
+            all block spectra before selecting values globally. ``"eager"``
+            spreads the bond dimension over sectors in proportion to their
+            current sizes before computing each block. Global mode keeps a
+            degenerate multiplet whole and may therefore exceed ``max_bond``.
+            Eager mode supports only absolute and relative cutoffs without
+            renormalization.
         absorb : {-1, 0, 1, None}
             How to absorb the singular values.
 
@@ -810,6 +829,7 @@ class ArrayCommon:
         kwargs.setdefault("max_bond", max_bond)
         kwargs.setdefault("absorb", absorb)
         kwargs.setdefault("renorm", renorm)
+        kwargs.setdefault("max_bond_mode", max_bond_mode)
         return self._split(**kwargs)
 
     def svd_via_eig(self, **kwargs):
@@ -826,10 +846,11 @@ class ArrayCommon:
     def svd_via_eig_truncated(
         self,
         cutoff=0.0,
-        cutoff_mode="rsum2",
+        cutoff_mode="rel",
         max_bond=None,
         absorb="both",
         renorm=False,
+        max_bond_mode="global",
         **kwargs,
     ):
         """Truncated singular value decomposition of this array, using
@@ -841,7 +862,7 @@ class ArrayCommon:
         cutoff : float, optional
             Singular value cutoff threshold.
         cutoff_mode : int or str, optional
-            How to perform the truncation:
+            How to perform the truncation. Defaults to ``"rel"``:
 
             - 1 or 'abs': trim values below ``cutoff``
             - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -852,6 +873,14 @@ class ArrayCommon:
 
         max_bond : int
             An explicit maximum bond dimension, use -1 for none.
+        max_bond_mode : {"global", "eager"}, optional
+            How to apply ``max_bond`` to sparse arrays. ``"global"`` computes
+            all block spectra before selecting values globally. ``"eager"``
+            spreads the bond dimension over sectors in proportion to their
+            current sizes before computing each block. Global mode keeps a
+            degenerate multiplet whole and may therefore exceed ``max_bond``.
+            Eager mode supports only absolute and relative cutoffs without
+            renormalization.
         absorb : {-1, 0, 1, None}
             How to absorb the singular values.
 
@@ -878,6 +907,7 @@ class ArrayCommon:
         kwargs.setdefault("max_bond", max_bond)
         kwargs.setdefault("absorb", absorb)
         kwargs.setdefault("renorm", renorm)
+        kwargs.setdefault("max_bond_mode", max_bond_mode)
         return self._split(**kwargs)
 
     def svd_rand_truncated(
@@ -887,6 +917,9 @@ class ArrayCommon:
         oversample=10,
         num_iterations=2,
         seed=None,
+        cutoff="auto",
+        cutoff_mode="rel",
+        max_bond_mode="eager",
         **kwargs,
     ) -> tuple["ArrayCommon", VectorCommon, "ArrayCommon"]:
         """Truncated singular value decomposition of this array, using
@@ -896,7 +929,8 @@ class ArrayCommon:
         Parameters
         ----------
         max_bond : int
-            Target rank / maximum bond dimension.
+            Target rank / maximum bond dimension. With sparse storage this is
+            spread over sectors in proportion to their current sizes.
         absorb : {-1, 0, 1, None}
             How to absorb the singular values.
 
@@ -911,6 +945,21 @@ class ArrayCommon:
             Number of power iterations for accuracy. Default is 2.
         seed : int, Generator or None, optional
             Random seed or generator for reproducibility.
+        cutoff : float or "auto", optional
+            Singular value cutoff threshold. Dynamic cutoffs are currently
+            only supported by the sparse backend. ``"auto"`` means no cutoff.
+        cutoff_mode : int or str, optional
+            How to perform the truncation. Defaults to ``"rel"``, so that
+            only the low-rank spectra are required. Cumulative modes are not
+            compatible with eager truncation.
+        max_bond_mode : {"global", "eager"}, optional
+            How to apply ``max_bond`` to sparse arrays. ``"eager"`` spreads
+            the bond dimension over sectors in proportion to their current
+            sizes before computing each block. ``"global"`` computes all
+            block spectra before selecting values globally. Global mode keeps
+            a degenerate multiplet whole and may therefore exceed
+            ``max_bond``. Eager mode supports only absolute and relative
+            cutoffs without renormalization.
 
         Returns
         -------
@@ -927,6 +976,12 @@ class ArrayCommon:
         kwargs.setdefault("oversample", oversample)
         kwargs.setdefault("num_iterations", num_iterations)
         kwargs.setdefault("seed", seed)
+        kwargs.setdefault("cutoff", 0.0 if cutoff == "auto" else cutoff)
+        kwargs.setdefault(
+            "cutoff_mode",
+            "rel" if cutoff_mode == "auto" else cutoff_mode,
+        )
+        kwargs.setdefault("max_bond_mode", max_bond_mode)
         return self._split(**kwargs)
 
     def qr(

--- a/symmray/flat/flat_array_common.py
+++ b/symmray/flat/flat_array_common.py
@@ -1556,6 +1556,7 @@ class FlatArrayCommon:
         *,
         fn=None,
         charge_side="auto",
+        max_bond_mode="global",
         **kwargs,
     ):
         """Main driver method for decomposing flat abelian arrays. This
@@ -1591,6 +1592,12 @@ class FlatArrayCommon:
             raise NotImplementedError(
                 "split only implemented for 2D FlatArrayCommon,"
                 f" got {self.ndim}D. Consider fusing first."
+            )
+
+        if max_bond_mode not in ("global", "eager"):
+            raise ValueError(
+                "max_bond_mode must be 'global' or 'eager', "
+                f"got {max_bond_mode!r}"
             )
         if kwargs.get("cutoff", 0.0) > 0.0:
             raise NotImplementedError(

--- a/symmray/linalg.py
+++ b/symmray/linalg.py
@@ -25,10 +25,12 @@ def eigh_truncated(x: ArrayCommon, *args, **kwargs):
 
     Parameters
     ----------
+    x : ArrayCommon
+        The 2D symmetric array to decompose, assumed to be hermitian.
     cutoff : float, optional
-        Absolute eigenvalue cutoff threshold.
+        Absolute eigenvalue cutoff threshold. Default is 0.0.
     cutoff_mode : int or str, optional
-        How to perform the truncation:
+        How to perform the truncation. Defaults to ``"rel"``:
 
         - 1 or 'abs': trim values below ``cutoff``
         - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -39,6 +41,13 @@ def eigh_truncated(x: ArrayCommon, *args, **kwargs):
 
     max_bond : int
         An explicit maximum bond dimension, use -1 for none.
+    max_bond_mode : {"global", "eager"}, optional
+        How to apply ``max_bond`` to sparse arrays. ``"global"`` computes all
+        block spectra before selecting values globally. ``"eager"`` spreads
+        the bond dimension over sectors in proportion to their current sizes
+        before computing each block. Global mode keeps a degenerate multiplet
+        whole and may therefore exceed ``max_bond``. Eager mode supports only
+        absolute and relative cutoffs without renormalization.
     absorb : {-1, 0, 1, None}
         How to absorb the eigenvalues.
 
@@ -119,7 +128,7 @@ def svd_truncated(x: ArrayCommon, *args, **kwargs):
     cutoff : float, optional
         Singular value cutoff threshold.
     cutoff_mode : int or str, optional
-        How to perform the truncation:
+        How to perform the truncation. Defaults to ``"rel"``:
 
         - 1 or 'abs': trim values below ``cutoff``
         - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -130,6 +139,13 @@ def svd_truncated(x: ArrayCommon, *args, **kwargs):
 
     max_bond : int
         An explicit maximum bond dimension, use -1 for none.
+    max_bond_mode : {"global", "eager"}, optional
+        How to apply ``max_bond`` to sparse arrays. ``"global"`` computes all
+        block spectra before selecting values globally. ``"eager"`` spreads
+        the bond dimension over sectors in proportion to their current sizes
+        before computing each block. Global mode keeps a degenerate multiplet
+        whole and may therefore exceed ``max_bond``. Eager mode supports only
+        absolute and relative cutoffs without renormalization.
     absorb : {-1, 0, 1, None}
         How to absorb the singular values.
 
@@ -161,7 +177,8 @@ def svd_rand_truncated(x: ArrayCommon, *args, **kwargs):
     Parameters
     ----------
     max_bond : int
-        Target rank / maximum bond dimension.
+        Target rank / maximum bond dimension. With sparse storage this is
+        spread over sectors in proportion to their current sizes.
     absorb : {-1, 0, 1, None}
         How to absorb the singular values.
 
@@ -176,6 +193,20 @@ def svd_rand_truncated(x: ArrayCommon, *args, **kwargs):
         Number of power iterations for accuracy. Default is 2.
     seed : int, Generator or None, optional
         Random seed or generator for reproducibility.
+    cutoff : float or "auto", optional
+        Singular value cutoff threshold. Dynamic cutoffs are currently only
+        supported by the sparse backend. ``"auto"`` means no cutoff.
+    cutoff_mode : int or str, optional
+        How to perform the truncation. Defaults to ``"rel"``, so that only the
+        low-rank spectra are required. Cumulative modes are not compatible with
+        eager truncation.
+    max_bond_mode : {"global", "eager"}, optional
+        How to apply ``max_bond`` to sparse arrays. ``"eager"`` spreads the
+        bond dimension over sectors in proportion to their current sizes
+        before computing each block. ``"global"`` computes all block spectra
+        before selecting values globally. Global mode keeps a degenerate
+        multiplet whole and may therefore exceed ``max_bond``. Eager mode
+        supports only absolute and relative cutoffs without renormalization.
 
     Returns
     -------
@@ -199,7 +230,7 @@ def svd_via_eig_truncated(x: ArrayCommon, *args, **kwargs):
     cutoff : float, optional
         Singular value cutoff threshold.
     cutoff_mode : int or str, optional
-        How to perform the truncation:
+        How to perform the truncation. Defaults to ``"rel"``:
 
         - 1 or 'abs': trim values below ``cutoff``
         - 2 or 'rel': trim values below ``s[0] * cutoff``
@@ -210,6 +241,13 @@ def svd_via_eig_truncated(x: ArrayCommon, *args, **kwargs):
 
     max_bond : int
         An explicit maximum bond dimension, use -1 for none.
+    max_bond_mode : {"global", "eager"}, optional
+        How to apply ``max_bond`` to sparse arrays. ``"global"`` computes all
+        block spectra before selecting values globally. ``"eager"`` spreads
+        the bond dimension over sectors in proportion to their current sizes
+        before computing each block. Global mode keeps a degenerate multiplet
+        whole and may therefore exceed ``max_bond``. Eager mode supports only
+        absolute and relative cutoffs without renormalization.
     absorb : {-1, 0, 1, None}
         How to absorb the singular values.
 

--- a/symmray/sparse/sparse_array_common.py
+++ b/symmray/sparse/sparse_array_common.py
@@ -1837,33 +1837,51 @@ class SparseArrayCommon:
 
     # --------------------------- linalg methods ---------------------------- #
 
-    def _split_abelian_full_spectrum(
+    def _split_abelian_dynamic(
         self,
         *,
         fn=None,
         charge_side="auto",
+        max_bond_mode="global",
         **kwargs,
     ):
-        """Helper method for decomposition methods involving dynamic
-        truncation, which require the full spectrum to be computed first since
-        truncation sizes will depend on all blocks.
+        """Helper method for decomposition methods involving global dynamic
+        truncation. Absolute and relative cutoffs can operate on pre-truncated
+        spectra, while cumulative cutoffs require the full spectra.
         """
         # pop out truncation and absorb options
         cutoff = kwargs.pop("cutoff", 0.0)
-        cutoff_mode = kwargs.pop("cutoff_mode", "rsum2")
+        cutoff_mode = _CUTOFF_MODE_MAP[kwargs.pop("cutoff_mode", "rel")]
         renorm = kwargs.pop("renorm", False)
         max_bond = kwargs.pop("max_bond", -1)
         absorb = kwargs.pop("absorb", "both")
         use_abs = kwargs.pop("use_abs", None)
 
-        # 1. compute full decomposition
+        if max_bond_mode == "eager":
+            if renorm:
+                raise ValueError(
+                    "renorm is not compatible with max_bond_mode='eager'"
+                )
+            if (cutoff > 0.0) and (cutoff_mode not in (1, 2)):
+                raise ValueError(
+                    "cumulative cutoff modes are not compatible with "
+                    "max_bond_mode='eager'"
+                )
+            initial_max_bond = max_bond
+            final_max_bond = -1
+        else:
+            initial_max_bond = -1
+            final_max_bond = max_bond
+
+        # 1. compute the required spectrum without absorbing
         left, s, right = self._split_abelian(
             fn=fn,
             charge_side=charge_side,
             cutoff=0.0,
             renorm=False,
-            max_bond=-1,
+            max_bond=initial_max_bond,
             absorb=None,
+            max_bond_mode=max_bond_mode,
             **kwargs,
         )
 
@@ -1888,8 +1906,8 @@ class SparseArrayCommon:
             s,
             right,
             cutoff=cutoff,
-            cutoff_mode=_CUTOFF_MODE_MAP[cutoff_mode],
-            max_bond=max_bond,
+            cutoff_mode=cutoff_mode,
+            max_bond=final_max_bond,
             absorb=absorb,
             renorm=renorm,
             use_abs=use_abs,
@@ -1901,6 +1919,7 @@ class SparseArrayCommon:
         *,
         fn=None,
         charge_side="auto",
+        max_bond_mode="global",
         **kwargs,
     ):
         """Main driver method for decomposing sparse abelian arrays. This
@@ -1936,23 +1955,29 @@ class SparseArrayCommon:
                 f" got {self.ndim}D. Consider fusing first."
             )
 
+        if max_bond_mode not in ("global", "eager"):
+            raise ValueError(
+                "max_bond_mode must be 'global' or 'eager', "
+                f"got {max_bond_mode!r}"
+            )
+
         # if max_bond is supplied make sure it is parsed
         if ("max_bond" in kwargs) and (kwargs["max_bond"] is None):
             kwargs["max_bond"] = -1
 
-        need_full_spectrum = (
+        max_bond = kwargs.get("max_bond", -1)
+        eager_max_bond = (max_bond_mode == "eager") and (max_bond > 0)
+        need_dynamic_truncation = (
             (kwargs.get("cutoff", -1.0) > 0.0)
             or (kwargs.get("renorm", 0) > 0)
-            or
-            # XXX: currently need full spectrum even for fixed max_bond
-            # as it may not be evenly distributed across blocks
-            (kwargs.get("max_bond", -1) > 0)
+            or ((max_bond > 0) and (max_bond_mode == "global"))
         )
-        if need_full_spectrum:
-            # must compute full spectrum first, *then* truncate / absorb
-            return self._split_abelian_full_spectrum(
+        if need_dynamic_truncation:
+            # compute the required spectrum first, *then* truncate / absorb
+            return self._split_abelian_dynamic(
                 fn=fn,
                 charge_side=charge_side,
+                max_bond_mode=max_bond_mode,
                 **kwargs,
             )
 
@@ -1968,8 +1993,28 @@ class SparseArrayCommon:
         if fn is None:
             fn = array_split
 
-        for sector, array in self.get_sector_block_pairs():
-            left, s, right = fn(array, **kwargs)
+        sector_block_pairs = tuple(self.get_sector_block_pairs())
+        if eager_max_bond and sector_block_pairs:
+            sector_ranks = tuple(
+                min(xp.shape(array)) for _, array in sector_block_pairs
+            )
+            sub_max_bonds = calc_sub_max_bonds(sector_ranks, max_bond)
+        else:
+            sub_max_bonds = itertools.repeat(None)
+
+        for (sector, array), sub_max_bond in zip(
+            sector_block_pairs, sub_max_bonds
+        ):
+            if sub_max_bond == 0:
+                # the total max bond cannot accommodate this sector
+                continue
+
+            if sub_max_bond is None:
+                split_kwargs = kwargs
+            else:
+                split_kwargs = {**kwargs, "max_bond": sub_max_bond}
+
+            left, s, right = fn(array, **split_kwargs)
 
             bond_charge = sector[1] if charge_side == "left" else sector[0]
             bond_charge_size = None
@@ -2191,29 +2236,51 @@ class SparseArrayCommon:
         return x
 
 
-def argsort(seq):
-    return sorted(range(len(seq)), key=seq.__getitem__)
-
-
 @functools.lru_cache(maxsize=2**14)
 def calc_sub_max_bonds(sizes, max_bond):
+    """Spread a total maximum bond over sectors based on their sizes."""
     if max_bond < 0:
         # no limit
         return sizes
 
-    # overall fraction of the total bond dimension to use
-    frac = max_bond / sum(sizes)
-    if frac >= 1.0:
+    total_size = sum(sizes)
+    if max_bond >= total_size:
         # keep all singular values
         return sizes
 
-    # number of singular values to keep in each sector
-    sub_max_bonds = [int(frac * sz) for sz in sizes]
+    num_sectors = len(sizes)
+    sub_max_bonds = [0] * num_sectors
+    if max_bond < num_sectors:
+        # some sectors have to be removed, so retain the largest ones
+        largest = sorted(
+            range(num_sectors),
+            key=lambda i: sizes[i],
+            reverse=True,
+        )
+        for i in largest[:max_bond]:
+            sub_max_bonds[i] = 1
+        return tuple(sub_max_bonds)
 
-    # distribute any remaining singular values to the smallest sectors
-    rem = max_bond - sum(sub_max_bonds)
+    # preserve every sector when the total max bond allows it
+    sub_max_bonds = [1] * num_sectors
+    capacities = [sz - 1 for sz in sizes]
+    remaining = max_bond - num_sectors
+    total_capacity = sum(capacities)
 
-    for i in argsort(sub_max_bonds)[:rem]:
+    # distribute the remaining modes proportionally to sector capacity
+    quotas = [remaining * capacity / total_capacity for capacity in capacities]
+    additions = [int(quota) for quota in quotas]
+    for i, addition in enumerate(additions):
+        sub_max_bonds[i] += addition
+
+    remainder = remaining - sum(additions)
+    largest_remainders = sorted(
+        range(num_sectors),
+        key=lambda i: quotas[i] - additions[i],
+        reverse=True,
+    )
+
+    for i in largest_remainders[:remainder]:
         sub_max_bonds[i] += 1
 
     return tuple(sub_max_bonds)
@@ -2252,58 +2319,66 @@ def truncate_svd_result_blocksparse(
     if renorm:
         raise NotImplementedError("renorm not implemented yet.")
 
-    if cutoff > 0.0:
+    if (cutoff > 0.0) or (max_bond > 0):
+        xp = s.get_namespace()
+
         # first combine all singular values into a single, sorted array
         sall = s.to_dense()
         if use_abs:
-            sall = ar.do("abs", sall, like=backend)
-        sall = ar.do("sort", sall, like=backend)
+            sall = xp.abs(sall)
+        sall = xp.sort(sall)
 
-        cutoff_mode = _CUTOFF_MODE_MAP[cutoff_mode]
+        abs_cutoff = None
+        if cutoff > 0.0:
+            cutoff_mode = _CUTOFF_MODE_MAP[cutoff_mode]
 
-        if cutoff_mode == 1:
-            # absolute cutoff
-            abs_cutoff = cutoff
-        elif cutoff_mode == 2:
-            # relative cutoff
-            abs_cutoff = sall[-1] * cutoff
-        else:
-            # possibly square singular values
-            power = {3: 2, 4: 2, 5: 1, 6: 1}[cutoff_mode]
-            if power == 1:
-                # sum1 or rsum1
-                cum_spow = ar.do("cumsum", sall, 0, like=backend)
+            if cutoff_mode == 1:
+                # absolute cutoff
+                abs_cutoff = cutoff
+            elif cutoff_mode == 2:
+                # relative cutoff
+                abs_cutoff = sall[-1] * cutoff
             else:
-                # sum2 or rsum2
-                cum_spow = ar.do("cumsum", sall**power, 0, like=backend)
+                # possibly square singular values
+                power = {3: 2, 4: 2, 5: 1, 6: 1}[cutoff_mode]
+                if power == 1:
+                    # sum1 or rsum1
+                    cum_spow = xp.cumsum(sall, 0)
+                else:
+                    # sum2 or rsum2
+                    cum_spow = xp.cumsum(sall**power, 0)
 
-            if cutoff_mode in (4, 6):
-                # rsum1 or rsum2: relative cumulative cutoff
-                cond = cum_spow >= cutoff * cum_spow[-1]
-            else:
-                # sum1 or sum2: absolute cumulative cutoff
-                cond = cum_spow >= cutoff
+                if cutoff_mode in (4, 6):
+                    # rsum1 or rsum2: relative cumulative cutoff
+                    cond = cum_spow >= cutoff * cum_spow[-1]
+                else:
+                    # sum1 or sum2: absolute cumulative cutoff
+                    cond = cum_spow >= cutoff
 
-            # translate to total number of singular values to keep
-            n_chi_all = ar.do("count_nonzero", cond, like=backend)
-            # and then to an absolute cutoff value
-            abs_cutoff = sall[-n_chi_all]
+                # translate to total number of singular values to keep
+                n_chi_all = xp.count_nonzero(cond)
+                # and then to an absolute cutoff value
+                abs_cutoff = sall[-n_chi_all]
 
         if 0 < max_bond < ar.size(sall):
             # also take into account a total maximum bond
             max_bond_cutoff = sall[-max_bond]
-            abs_cutoff = max(abs_cutoff, max_bond_cutoff)
+            if abs_cutoff is None:
+                abs_cutoff = max_bond_cutoff
+            else:
+                abs_cutoff = max(abs_cutoff, max_bond_cutoff)
 
-        # now find number of values to keep per sector
-        sub_max_bonds = [
-            int(ar.do("count_nonzero", ss >= abs_cutoff, like=backend))
-            for ss in s.get_all_blocks()
-        ]
+        if abs_cutoff is None:
+            sub_max_bonds = tuple(map(ar.size, s.get_all_blocks()))
+        else:
+            # now find number of values to keep per sector
+            sub_max_bonds = []
+            for ss in s.get_all_blocks():
+                if use_abs:
+                    ss = xp.abs(ss)
+                sub_max_bonds.append(int(xp.count_nonzero(ss >= abs_cutoff)))
     else:
-        # size of each sector
-        sector_sizes = tuple(map(ar.size, s.get_all_blocks()))
-        # distribute max_bond proportionally to sector sizes
-        sub_max_bonds = calc_sub_max_bonds(sector_sizes, max_bond)
+        sub_max_bonds = tuple(map(ar.size, s.get_all_blocks()))
 
     new_inner_chargemap = {}
     for (c0, c1), n_chi in zip(U.sectors, sub_max_bonds):

--- a/tests/test_flat/test_flat_abelian_linalg.py
+++ b/tests/test_flat/test_flat_abelian_linalg.py
@@ -352,6 +352,38 @@ def test_flat_svd_rand_truncated_ar_dispatch(symmetry, d1, d2, seed=42):
     assert s.size <= 8
 
 
+@pytest.mark.parametrize("max_bond_mode", ["global", "eager"])
+def test_flat_svd_rand_truncated_max_bond_mode(max_bond_mode):
+    fx = get_zn_blocksparse_flat_compat(
+        "Z2",
+        shape=[8, 8],
+        seed=42,
+    ).to_flat()
+
+    u, s, vh = fx.svd_rand_truncated(
+        max_bond=4,
+        max_bond_mode=max_bond_mode,
+        absorb=None,
+        seed=42,
+    )
+
+    u.check()
+    s.check()
+    vh.check()
+    assert s.size <= 4
+
+
+def test_flat_svd_truncated_invalid_max_bond_mode():
+    fx = get_zn_blocksparse_flat_compat(
+        "Z2",
+        shape=[8, 8],
+        seed=42,
+    ).to_flat()
+
+    with pytest.raises(ValueError, match="max_bond_mode"):
+        fx.svd_truncated(max_bond=4, max_bond_mode="invalid")
+
+
 @pytest.mark.parametrize("symmetry", ["Z2", "Z3", "Z4"])
 @pytest.mark.parametrize("d", [2, 3])
 @pytest.mark.parametrize("dtype", ["float64", "complex128", "complex64"])

--- a/tests/test_sparse/test_sparse_abelian_linalg.py
+++ b/tests/test_sparse/test_sparse_abelian_linalg.py
@@ -1,3 +1,5 @@
+import warnings
+
 import autoray as ar
 import pytest
 from numpy.testing import assert_allclose
@@ -153,6 +155,280 @@ def test_svd_via_eig_truncated_ar_dispatch(symmetry, d0, d1, seed=42):
     assert s.size <= 2
 
 
+@pytest.mark.parametrize("absorb", [None, -1, 0, 1])
+@pytest.mark.parametrize(
+    "max_bond, expected_chargemap",
+    [
+        (6, {0: 4, 1: 1, 2: 1}),
+        (3, {0: 1, 1: 1, 2: 1}),
+        (2, {0: 1, 1: 1}),
+    ],
+)
+def test_svd_rand_truncated_max_bond(
+    absorb,
+    max_bond,
+    expected_chargemap,
+):
+    x = sr.utils.get_rand(
+        "Z3",
+        shape=({0: 10, 1: 2, 2: 1}, {0: 10, 1: 2, 2: 1}),
+        duals=(False, True),
+        seed=42,
+    )
+
+    with warnings.catch_warnings():
+        # every blockwise randomized SVD should receive a finite max_bond
+        warnings.filterwarnings(
+            "error",
+            message="Using 'svd:rand' without `max_bond`",
+        )
+        u, s, vh = ar.do(
+            "svd_rand_truncated",
+            x,
+            max_bond=max_bond,
+            absorb=absorb,
+            seed=42,
+        )
+
+    u.check()
+    vh.check()
+    assert u.indices[1].chargemap == expected_chargemap
+    assert vh.indices[0].chargemap == expected_chargemap
+
+    if absorb is None:
+        s.check()
+        assert s.size == max_bond
+    else:
+        assert s is None
+
+    assert u.shape[0] == x.shape[0]
+    assert vh.shape[1] == x.shape[1]
+    if max_bond >= len(x.sectors):
+        if absorb is None:
+            xr = sr.einsum("ij,j,jk->ik", u, s, vh)
+        else:
+            xr = u @ vh
+        xr.check()
+        assert xr.shape == x.shape
+        assert xr.charge == x.charge
+
+
+@pytest.mark.parametrize(
+    "cutoff, cutoff_mode",
+    [
+        (0.5, None),
+        (100.0, "abs"),
+    ],
+)
+def test_svd_rand_truncated_dynamic_cutoff(cutoff, cutoff_mode):
+    import numpy as np
+
+    x = sr.utils.get_rand(
+        "Z3",
+        shape=({0: 10, 1: 2, 2: 1}, {0: 10, 1: 2, 2: 1}),
+        duals=(False, True),
+        seed=42,
+    )
+    x.set_block((1, 1), np.diag([1000.0, 0.0]))
+
+    kwargs = {}
+    if cutoff_mode is not None:
+        kwargs["cutoff_mode"] = cutoff_mode
+
+    with warnings.catch_warnings():
+        # every blockwise randomized SVD should receive a finite max_bond
+        warnings.filterwarnings(
+            "error",
+            message="Using 'svd:rand' without `max_bond`",
+        )
+        u, s, vh = x.svd_rand_truncated(
+            max_bond=2,
+            cutoff=cutoff,
+            absorb=None,
+            seed=42,
+            **kwargs,
+        )
+
+    reference_mode = "rel" if cutoff_mode is None else cutoff_mode
+    _, s_reference, _ = x.svd_truncated(
+        max_bond=2,
+        cutoff=cutoff,
+        cutoff_mode=reference_mode,
+        absorb=None,
+    )
+
+    u.check()
+    s.check()
+    vh.check()
+    assert s.sectors == (1,)
+    s.test_allclose(s_reference)
+
+
+def test_svd_truncated_default_relative_cutoff_max_bond_exact():
+    x = sr.utils.get_rand(
+        "Z3",
+        shape=({0: 10, 1: 1, 2: 1}, {0: 10, 1: 1, 2: 1}),
+        duals=(False, True),
+        seed=42,
+    )
+
+    _, s, _ = x.svd_truncated(
+        max_bond=6,
+        cutoff=1e-12,
+        absorb=None,
+    )
+    _, s_reference, _ = x.svd_truncated(
+        max_bond=6,
+        cutoff=1e-12,
+        cutoff_mode="rsum2",
+        absorb=None,
+    )
+
+    s.check()
+    assert s.sectors == s_reference.sectors
+    s.test_allclose(s_reference)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "svd_truncated",
+        "svd_via_eig_truncated",
+        "eigh_truncated",
+    ],
+)
+@pytest.mark.parametrize(
+    "max_bond_mode, expected_sizes, expected_values",
+    [
+        (None, {1: 2, 2: 1}, [80.0, 90.0, 100.0]),
+        ("global", {1: 2, 2: 1}, [80.0, 90.0, 100.0]),
+        ("eager", {0: 1, 1: 1, 2: 1}, [10.0, 80.0, 100.0]),
+    ],
+)
+def test_truncated_max_bond_modes(
+    method,
+    max_bond_mode,
+    expected_sizes,
+    expected_values,
+):
+    import numpy as np
+
+    x = sr.AbelianArray.from_blocks(
+        {
+            (0, 0): np.diag(np.arange(1.0, 11.0)),
+            (1, 1): np.diag([100.0, 90.0]),
+            (2, 2): np.array([[80.0]]),
+        },
+        duals=(False, True),
+        symmetry="Z3",
+    )
+
+    kwargs = {}
+    if max_bond_mode is not None:
+        kwargs["max_bond_mode"] = max_bond_mode
+
+    _, s, _ = getattr(x, method)(
+        cutoff=0.0,
+        max_bond=3,
+        absorb=None,
+        **kwargs,
+    )
+
+    s.check()
+    actual_sizes = {c: len(s.get_block(c)) for c in s.sectors}
+    assert actual_sizes == expected_sizes
+    assert_allclose(sorted(s.to_dense()), expected_values)
+
+
+def test_svd_rand_truncated_global_max_bond():
+    import numpy as np
+
+    x = sr.AbelianArray.from_blocks(
+        {
+            (0, 0): np.diag(np.arange(1.0, 11.0)),
+            (1, 1): np.diag([100.0, 90.0]),
+            (2, 2): np.array([[80.0]]),
+        },
+        duals=(False, True),
+        symmetry="Z3",
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Using 'svd:rand' without `max_bond`",
+        )
+        _, s, _ = x.svd_rand_truncated(
+            max_bond=3,
+            max_bond_mode="global",
+            absorb=None,
+            seed=42,
+        )
+
+    s.check()
+    actual_sizes = {c: len(s.get_block(c)) for c in s.sectors}
+    assert actual_sizes == {1: 2, 2: 1}
+    assert_allclose(sorted(s.to_dense()), [80.0, 90.0, 100.0])
+
+
+def test_truncated_global_max_bond_preserves_degeneracy():
+    import numpy as np
+
+    x = sr.AbelianArray.from_blocks(
+        {
+            (0, 0): np.array([[5.0]]),
+            (1, 1): np.diag([2.0, 2.0]),
+            (2, 2): np.diag([2.0, 2.0, 1.0]),
+        },
+        duals=(False, True),
+        symmetry="Z3",
+    )
+
+    _, s, _ = x.svd_truncated(
+        cutoff=0.0,
+        max_bond=3,
+        max_bond_mode="global",
+        absorb=None,
+    )
+
+    s.check()
+    assert s.size == 5
+    assert_allclose(sorted(s.to_dense()), [2.0, 2.0, 2.0, 2.0, 5.0])
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        (
+            {"cutoff": 1e-3, "cutoff_mode": "rsum2"},
+            "cumulative cutoff modes",
+        ),
+        ({"cutoff": 1e-3, "renorm": True}, "renorm"),
+    ],
+)
+def test_truncated_eager_unsupported_options(kwargs, message):
+    x = sr.utils.get_rand(
+        "Z3",
+        shape=({0: 4, 1: 2, 2: 1}, {0: 4, 1: 2, 2: 1}),
+        duals=(False, True),
+        seed=42,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        x.svd_truncated(
+            max_bond=3,
+            max_bond_mode="eager",
+            **kwargs,
+        )
+
+
+def test_truncated_invalid_max_bond_mode():
+    x = sr.utils.get_rand("Z2", (4, 4), seed=42)
+
+    with pytest.raises(ValueError, match="max_bond_mode"):
+        x.svd_truncated(max_bond=2, max_bond_mode="invalid")
+
+
 @pytest.mark.parametrize("symmetry", ("Z2", "U1", "Z2Z2", "U1U1"))
 @pytest.mark.parametrize("d", (2, 3, 4, 5, 7))
 @pytest.mark.parametrize("seed", range(1))
@@ -231,7 +507,7 @@ def test_eigh_truncated_cutoff_max_bond(symmetry, seed):
     # cutoff only
     _, s, _ = sr.linalg.eigh_truncated(
         x,
-        cutoff=3e-2,
+        cutoff=3e-1,
         absorb=None,
     )
     assert s.size < x.shape[0]
@@ -253,6 +529,32 @@ def test_eigh_truncated_cutoff_max_bond(symmetry, seed):
         absorb=None,
     )
     assert s.size <= 7
+
+
+def test_eigh_truncated_negative_relative_cutoff_max_bond():
+    import numpy as np
+
+    x = sr.AbelianArray.from_blocks(
+        {
+            (0, 0): np.diag([-9.0, -8.0, 1.0]),
+            (1, 1): np.diag([-2.0, 1.0]),
+            (2, 2): np.array([[-3.0]]),
+        },
+        duals=(False, True),
+        symmetry="Z3",
+    )
+
+    _, s, _ = x.eigh_truncated(
+        cutoff=0.5,
+        cutoff_mode="rel",
+        max_bond=2,
+        absorb=None,
+        positive=False,
+    )
+
+    s.check()
+    assert s.sectors == (0,)
+    assert_allclose(sorted(abs(s.to_dense())), [8.0, 9.0])
 
 
 @pytest.mark.parametrize("symmetry", ("Z2", "U1", "Z2Z2", "U1U1"))

--- a/tests/test_sparse/test_sparse_fermionic_linalg.py
+++ b/tests/test_sparse/test_sparse_fermionic_linalg.py
@@ -1,3 +1,5 @@
+import warnings
+
 import autoray as ar
 import pytest
 
@@ -210,7 +212,7 @@ def test_svd_truncated_cutoff_max_bond(symmetry, seed):
     _, s, _ = ar.do(
         "svd_truncated",
         x,
-        cutoff=3e-2,
+        cutoff=3e-1,
         absorb=None,
     )
     assert s.size < 80
@@ -355,6 +357,46 @@ def test_svd_via_eig_truncated_max_bond(symmetry, seed):
     assert s.size <= 2
 
 
+@pytest.mark.parametrize("absorb", [None, -1, 0, 1])
+def test_svd_rand_truncated_max_bond(absorb):
+    x = sr.utils.get_rand(
+        "Z3",
+        shape=({0: 8, 1: 2, 2: 1}, {0: 8, 1: 2, 2: 1}),
+        duals=(False, True),
+        fermionic=True,
+        seed=42,
+    )
+    x.randomize_phases(seed=43, inplace=True)
+
+    with warnings.catch_warnings():
+        # every blockwise randomized SVD should receive a finite max_bond
+        warnings.filterwarnings(
+            "error",
+            message="Using 'svd:rand' without `max_bond`",
+        )
+        u, s, vh = x.svd_rand_truncated(
+            max_bond=3,
+            absorb=absorb,
+            seed=42,
+        )
+
+    u.check()
+    vh.check()
+    assert u.indices[1].chargemap == {0: 1, 1: 1, 2: 1}
+    assert vh.indices[0].chargemap == {0: 1, 1: 1, 2: 1}
+
+    if absorb is None:
+        s.check()
+        xr = sr.einsum("ij,j,jk->ik", u, s, vh)
+    else:
+        assert s is None
+        xr = u @ vh
+
+    xr.check()
+    assert xr.shape == x.shape
+    assert xr.charge == x.charge
+
+
 @pytest.mark.parametrize("symm", ("Z2", "U1", "Z2Z2", "U1U1"))
 @pytest.mark.parametrize("seed", range(10))
 @pytest.mark.parametrize("dtype", ("float64", "complex128"))
@@ -440,7 +482,7 @@ def test_eigh_truncated_fermionic_cutoff_max_bond(symmetry, seed):
     # cutoff only
     _, s, _ = sr.linalg.eigh_truncated(
         x,
-        cutoff=3e-2,
+        cutoff=3e-1,
         absorb=None,
     )
     assert s.size < x.shape[0]


### PR DESCRIPTION
This PR makes various changes to linalg decompositions:

- sparse `svd_rand_truncated` (method="svd:rand" in quimb) now eagerly spreads the given `max_bond` over current sectors proportionally. Otherwise, waiting for th global spectrum to truncate offers no speedup.
- `max_bond_mode`, which governs this, is now an option. The default 'global' mode is now turned on for cutoff=0.0 as well.
- default `cutoff_mode` has changed to 'rel', which doesn't require full spectrum, and reflects upcoming defaults in quimb